### PR TITLE
[5.5.0] Add arrays and QOL changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.15.11
 
 # Mod Properties
 # REMEMBER TO CHANGE THE VALUE IN FABRIC.MOD.JSON
-mod_version=5.0.0
+mod_version=5.5.0
 maven_group=hudder
 archives_base_name=hudder
 

--- a/src/main/java/io/github/ngspace/hudder/Hudder.java
+++ b/src/main/java/io/github/ngspace/hudder/Hudder.java
@@ -51,6 +51,11 @@ import net.minecraft.util.logging.LoggerPrintStream;
  * then you're gonna have a bad time.</h1>
  */
 public class Hudder implements ModInitializer {
+	/* 01 - setting a set to a value
+	 */
+	
+	
+	
     public static final String MOD_ID = "hudder";
 	
     private static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
@@ -91,7 +96,7 @@ public class Hudder implements ModInitializer {
 		
 		ins = MinecraftClient.getInstance();
 
-		String[] defaultfiles = {"tutorial","hand","armor","hud","basic","hud.js","hotbar.js"};
+		String[] defaultfiles = {"tutorial","hand","armor","hud","basic","hud.js","hotbar.js", "fibonacci"};
 		String[] defaulttextures = {"pointer.png","selection.png"};
 		for (String file : defaultfiles) {
 			File dest = new File(HudFileUtils.FOLDER, file);
@@ -231,7 +236,7 @@ public class Hudder implements ModInitializer {
     			for (Consumer<ATextCompiler> con : postcomplistners) con.accept(config.compiler);
     		}
 		} catch (CompileException e) {
-			LastFailMessage = e.getLocalizedMessage()+(e.line!=-1?" at line "+(e.line+1)+" col "+e.col:"");
+			LastFailMessage = e.getFailureMessage();
 			result = null;
 		} catch (Exception e) {
 			LastFailMessage = "E: " + e.getLocalizedMessage();

--- a/src/main/java/io/github/ngspace/hudder/HudderRenderer.java
+++ b/src/main/java/io/github/ngspace/hudder/HudderRenderer.java
@@ -27,7 +27,7 @@ public class HudderRenderer {
 		String[] lines = FailMessage.split(NL_REGEX);
 		int y = 1;
 		for (String line : lines) {
-			renderTextLine(context, line, 1, y, 0xFF5555, 1, false, true, 0xd6d6d6);
+			renderTextLine(context, line, 1, y, 0xFF5555, 1, true, true, 0xd6d6d6);
 			y+=9;
 		}
 	}
@@ -90,7 +90,7 @@ public class HudderRenderer {
     }
 
 	public void renderTextLine(DrawContext context, String text, int x, int y, int color, float scale, boolean shadow,
-			boolean background, int backgroundColor) {
+			boolean background, long backgroundColor) {
 		if (background&&!"".equals(text))
 			renderBlock(context,x-1f,y-1f,Hudder.ins.textRenderer.getWidth(text)+2f,9f+1f,backgroundColor);
         RenderSystem.enableBlend();
@@ -108,18 +108,26 @@ public class HudderRenderer {
         RenderSystem.disableBlend();
     }
 	
-	public void renderBlock(DrawContext context, float x, float y, float width, float height, int color) {
+	public void renderBlock(DrawContext context, float x, float y, float width, float height, long rgb) {
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-        BufferBuilder bgBuilder = 
-        		Tessellator.getInstance().begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
+        int alpha = (int) ((rgb >> 24) & 0xFF);
+        int red =   (int) ((rgb >> 16) & 0xFF);
+        int green = (int) ((rgb >>  8) & 0xFF);
+        int blue =  (int) ((rgb      ) & 0xFF);
+
+        BufferBuilder bgBuilder =  Tessellator.getInstance().begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR);
         Matrix4f matrix = context.getMatrices().peek().getPositionMatrix();
-        bgBuilder.vertex(matrix, x, y+height, 0f).color(color);
-        bgBuilder.vertex(matrix, x+width, y+height, 0f).color(color);
-        bgBuilder.vertex(matrix, x+width, y, 0f).color(color);
-        bgBuilder.vertex(matrix, x, y, 0f).color(color);
+        bgBuilder.vertex(matrix, x, y+height, 0f).color(red,green,blue,alpha);
+        bgBuilder.vertex(matrix, x+width, y+height, 0f).color(red,green,blue,alpha);
+        bgBuilder.vertex(matrix, x+width, y, 0f).color(red,green,blue,alpha);
+        bgBuilder.vertex(matrix, x, y, 0f).color(red,green,blue,alpha);
+        RenderSystem.resetTextureMatrix();
         BufferRenderer.drawWithGlobalProgram(bgBuilder.end());
+        BufferRenderer.reset();
         RenderSystem.disableBlend();
+//		System.out.println(color);
+//		System.out.println(0xff7e6da8);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/compilers/ATextCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/ATextCompiler.java
@@ -17,8 +17,6 @@ public abstract class ATextCompiler {
 	public void put(String key, Object value) {variables.put(key, value);}
 	public Object get(String key) {return variables.get(key);}
 	
-	public abstract void reset();
-	
 	public CharPosition getPosition(int ind, String string) {
 		int line = 0;
 		int charpos = 0;

--- a/src/main/java/io/github/ngspace/hudder/compilers/ATextCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/ATextCompiler.java
@@ -18,4 +18,45 @@ public abstract class ATextCompiler {
 	public Object get(String key) {return variables.get(key);}
 	
 	public abstract void reset();
+	
+	public CharPosition getPosition(int ind, String string) {
+		int line = 0;
+		int charpos = 0;
+		
+		for (int i = 0;i<ind;i++) {
+			if (string.charAt(i)=='\n') {
+				line++;
+				charpos = 0;
+				continue;
+			}
+			charpos++;
+		}
+		return new CharPosition(line, charpos);
+	}
+	public CharPosition getPosition(CharPosition charPosition, int ind, String j) {
+		int line = charPosition.line;
+		int charpos = charPosition.charpos;
+		if (line==-1||charpos==-1) {
+			line = 0;
+			charpos = 0;
+		}
+		
+		for (int i = 0;i<ind;i++) {
+			if (j.charAt(i)=='\n') {
+				line++;
+				charpos = 0;
+				continue;
+			}
+			charpos++;
+		}
+		return new CharPosition(line, charpos);
+	}
+	public static class CharPosition {
+		public final int line;
+		public final int charpos;
+		public CharPosition(int line, int charpos) {
+			this.line = line;
+			this.charpos = charpos;
+		}
+	}
 }

--- a/src/main/java/io/github/ngspace/hudder/compilers/AVarTextCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/AVarTextCompiler.java
@@ -39,11 +39,6 @@ public abstract class AVarTextCompiler extends ATextCompiler {
 		return null;
 	}
 
-	public boolean isDynamicVariable(String key) {
-		return getSystemVariable(key)==null&&getOperator(key)==null&&!key.contains("+")&&!key.contains("-")
-				&&!key.contains("/")&&!key.contains("*")&&!key.contains("%")&&!key.contains("=")&&!key.contains("(")
-				&&!key.contains(")");
-	}
 	public Object getDynamicVariable(String key) {
 		Object obj = get(key);
 		if (obj!=null) return obj;

--- a/src/main/java/io/github/ngspace/hudder/compilers/EmptyCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/EmptyCompiler.java
@@ -10,5 +10,5 @@ public class EmptyCompiler extends ATextCompiler {
 
 	@Override public Object getVariable(String key) throws CompileException {return null;}
 
-	@Override public void reset() {/*Do nothin*/}
+//	@Override public void reset() {/*Do nothin*/}
 }

--- a/src/main/java/io/github/ngspace/hudder/compilers/HudderV2Compiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/HudderV2Compiler.java
@@ -23,7 +23,8 @@ public class HudderV2Compiler extends AV2Compiler {
 	public static final int METHOD_STATE = 3;
 	public static final int HASHTAG_STATE = 4;
 
-	@Override public V2Runtime buildRuntime(ConfigInfo info, String text, CharPosition charPosition) throws CompileException {
+	@Override public V2Runtime buildRuntime(ConfigInfo info, String text, CharPosition charPosition)
+			throws CompileException {
 		V2Runtime runtime = new V2Runtime();
 		
 		StringBuilder elemBuilder = new StringBuilder();
@@ -102,9 +103,8 @@ public class HudderV2Compiler extends AV2Compiler {
 						bracketscount--;
 						if (bracketscount==0) {
 							var pos = getPosition(charPosition, savedind, text);
-							int line = pos.line;
-							int charpos = pos.charpos;
-							runtime.addRuntimeElement(new VariableV2RuntimeElement(elemBuilder.toString(), this, runtime, line, charpos));
+							runtime.addRuntimeElement(new VariableV2RuntimeElement(elemBuilder.toString(), this,
+									runtime, pos.line, pos.charpos));
 							elemBuilder.setLength(0);
 							compileState = TEXT_STATE;
 						} else elemBuilder.append(c);
@@ -124,7 +124,9 @@ public class HudderV2Compiler extends AV2Compiler {
 						case '%':
 							compileState = TEXT_STATE;
 							builder = addToArray(builder,elemBuilder.toString().trim());
-							runtime.addRuntimeElement(new BasicConditionV2RuntimeElement(builder, this, info, runtime));
+							var pos = getPosition(charPosition, savedind, text);
+							runtime.addRuntimeElement(new BasicConditionV2RuntimeElement(builder, this, info, runtime,
+									pos.line, pos.charpos));
 							elemBuilder.setLength(0);
 							break;
 						case '"':
@@ -166,7 +168,7 @@ public class HudderV2Compiler extends AV2Compiler {
 						var pos = getPosition(charPosition, savedind, text);
 						int line = pos.line;
 						int charpos = pos.charpos;
-						runtime.addRuntimeElement(new MethodV2RuntimeElement(builder, this, info, runtime, line, charpos));
+						runtime.addRuntimeElement(new MethodV2RuntimeElement(builder,this,info,runtime,line,charpos));
 						elemBuilder.setLength(0);
 						builder = new String[0];
 						cleanup = true;
@@ -225,10 +227,12 @@ public class HudderV2Compiler extends AV2Compiler {
 						break;
 					}
 					if (isWhile) {
-						runtime.addRuntimeElement(new WhileV2RuntimeElement(info, cond, cmds, this, runtime, getPosition(charPosition, savedind+1, "\n"+text)));
+						runtime.addRuntimeElement(new WhileV2RuntimeElement(info, cond, cmds, this, runtime,
+								getPosition(charPosition, savedind+1, "\n"+text)));
 						break;
 					}
-					runtime.addRuntimeElement(new IfV2RuntimeElement(info, cond, cmds, this, runtime, getPosition(charPosition, savedind+1, "\n"+text)));
+					runtime.addRuntimeElement(new IfV2RuntimeElement(info, cond, cmds, this, runtime,
+							getPosition(charPosition, savedind+1, "\n"+text)));
 					break;
 				}
 				default: throw new CompileException("Unknown compile state: " + compileState);

--- a/src/main/java/io/github/ngspace/hudder/compilers/HudderV2Compiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/HudderV2Compiler.java
@@ -23,7 +23,7 @@ public class HudderV2Compiler extends AV2Compiler {
 	public static final int METHOD_STATE = 3;
 	public static final int HASHTAG_STATE = 4;
 
-	@Override public V2Runtime buildRuntime(ConfigInfo info, String text) throws CompileException {
+	@Override public V2Runtime buildRuntime(ConfigInfo info, String text, CharPosition charPosition) throws CompileException {
 		V2Runtime runtime = new V2Runtime();
 		
 		StringBuilder elemBuilder = new StringBuilder();
@@ -36,6 +36,7 @@ public class HudderV2Compiler extends AV2Compiler {
 		boolean backslashsafe = false;
 		boolean condSafe = false;
 		boolean safeappend = false;
+		int savedind = 0;
 		
 		boolean cleanup = false;
 		int cleanup_amount = ConfigManager.getConfig().methodBuffer;
@@ -62,24 +63,28 @@ public class HudderV2Compiler extends AV2Compiler {
 							builder = new String[] {};
 							runtime.addRuntimeElement(new StringV2RuntimeElement(elemBuilder.toString(), false));
 							elemBuilder.setLength(0);
+							savedind = ind;
 							break;
 						case '{':
 							compileState = VARIABLE_STATE;
 							runtime.addRuntimeElement(new StringV2RuntimeElement(elemBuilder.toString(), false));
 							elemBuilder.setLength(0);
 							bracketscount = 1;
+							savedind = ind;
 							break;
 						case ';':
 							compileState = METHOD_STATE;
 							runtime.addRuntimeElement(new StringV2RuntimeElement(elemBuilder.toString(), true));
 							elemBuilder.setLength(0);
 							builder = new String[] {};
+							savedind = ind;
 							break;
 						case '#':
 							compileState = HASHTAG_STATE;
 							builder = new String[] {};
 							runtime.addRuntimeElement(new StringV2RuntimeElement(elemBuilder.toString(), false));
 							elemBuilder.setLength(0);
+							savedind = ind;
 							break;
 						case '&':
 							elemBuilder.append('\u00A7');
@@ -96,7 +101,10 @@ public class HudderV2Compiler extends AV2Compiler {
 					} else if (c=='}') {
 						bracketscount--;
 						if (bracketscount==0) {
-							runtime.addRuntimeElement(new VariableV2RuntimeElement(elemBuilder.toString(), this, runtime));
+							var pos = getPosition(charPosition, savedind, text);
+							int line = pos.line;
+							int charpos = pos.charpos;
+							runtime.addRuntimeElement(new VariableV2RuntimeElement(elemBuilder.toString(), this, runtime, line, charpos));
 							elemBuilder.setLength(0);
 							compileState = TEXT_STATE;
 						} else elemBuilder.append(c);
@@ -155,7 +163,10 @@ public class HudderV2Compiler extends AV2Compiler {
 					}
 					if (compileState!=METHOD_STATE) {
 						builder = HudderUtils.processParemeters(elemBuilder.toString());
-						runtime.addRuntimeElement(new MethodV2RuntimeElement(builder, this, info, runtime));
+						var pos = getPosition(charPosition, savedind, text);
+						int line = pos.line;
+						int charpos = pos.charpos;
+						runtime.addRuntimeElement(new MethodV2RuntimeElement(builder, this, info, runtime, line, charpos));
 						elemBuilder.setLength(0);
 						builder = new String[0];
 						cleanup = true;
@@ -208,15 +219,16 @@ public class HudderV2Compiler extends AV2Compiler {
 							builder = addToArray(builder, elemBuilder.toString().trim().toLowerCase());
 						String name = builder[0];
 						String[] args = Arrays.copyOfRange(builder, 1, builder.length);
-						runtime.methodHandler.register(cmds, args, name);
+						var pos = getPosition(charPosition, savedind+1, "\n"+text);
+						methodHandler.register(cmds, args, name, pos.line, pos.charpos);
 						elemBuilder.setLength(0);
 						break;
 					}
 					if (isWhile) {
-						runtime.addRuntimeElement(new WhileV2RuntimeElement(info, cond, cmds, this, runtime));
+						runtime.addRuntimeElement(new WhileV2RuntimeElement(info, cond, cmds, this, runtime, getPosition(charPosition, savedind+1, "\n"+text)));
 						break;
 					}
-					runtime.addRuntimeElement(new IfV2RuntimeElement(info, cond, cmds, this, runtime));
+					runtime.addRuntimeElement(new IfV2RuntimeElement(info, cond, cmds, this, runtime, getPosition(charPosition, savedind+1, "\n"+text)));
 					break;
 				}
 				default: throw new CompileException("Unknown compile state: " + compileState);
@@ -229,7 +241,7 @@ public class HudderV2Compiler extends AV2Compiler {
 		
 		return runtime;
 	}
-	
+
 	protected String getCompilerErrorMessage(int compileState) {
 		StringBuilder strb = new StringBuilder();
 		strb.append(switch(compileState) {

--- a/src/main/java/io/github/ngspace/hudder/compilers/JavaScriptCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/JavaScriptCompiler.java
@@ -303,5 +303,4 @@ public class JavaScriptCompiler extends AVarTextCompiler {
 	 * @param <E> any exception this consumer might throw.
 	 */
 	@FunctionalInterface public static interface Cons<E extends Exception> extends NoThisAndNoResult<E> {}
-	@Override public void reset() {cache.clear();variables.clear();}
 }

--- a/src/main/java/io/github/ngspace/hudder/compilers/UnaccessableTestCompiler.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/UnaccessableTestCompiler.java
@@ -14,6 +14,4 @@ public class UnaccessableTestCompiler extends ATextCompiler {
 		//I made a typo... I am keeping this here...
 		return "Advanchment unlocked: How did we get here?";
 	}
-
-	@Override public void reset() {/*Do nothin*/}
 }

--- a/src/main/java/io/github/ngspace/hudder/compilers/utils/CompileException.java
+++ b/src/main/java/io/github/ngspace/hudder/compilers/utils/CompileException.java
@@ -7,5 +7,10 @@ public class CompileException extends Exception {
 	public CompileException(String string) {this(string,-1,0);}
 	public CompileException(String string, int line, int col) {super(string);this.line = line;this.col = col;}
 	public CompileException(String string, int line, int col, Exception e) {super(string,e);this.line = line;this.col = col;}
+	
 	private static final long serialVersionUID = -5301919978870515553L;
+
+	public String getFailureMessage() {
+		return getLocalizedMessage()+(col>-1?"\nat line "+(line+1)+" col "+col:"");
+	}
 }

--- a/src/main/java/io/github/ngspace/hudder/config/ConfigInfo.java
+++ b/src/main/java/io/github/ngspace/hudder/config/ConfigInfo.java
@@ -25,6 +25,7 @@ public class ConfigInfo {
 	
 	/* EXPOSED :flushed: */
 	@Expose public Map<String, Object> globalVariables = new HashMap<String, Object>();
+	@Expose public Map<String, Object> savedVariables = new HashMap<String, Object>();
     @Expose public String compilertype = "hudder";
 	@Expose public String mainfile = "tutorial";
     @Expose public boolean enabled = true;

--- a/src/main/java/io/github/ngspace/hudder/config/ConfigInfo.java
+++ b/src/main/java/io/github/ngspace/hudder/config/ConfigInfo.java
@@ -41,7 +41,7 @@ public class ConfigInfo {
 	@Expose public int methodBuffer = 2;
 	//V3.0.0
 	@Expose public int backgroundcolor = 0x86353535;
-	@Expose public boolean background = false;
+	@Expose public boolean background = true;
 	@Expose public boolean removegui = false;
 	@Expose public boolean limitrate = true;
 	/**

--- a/src/main/java/io/github/ngspace/hudder/config/ConfigMenu.java
+++ b/src/main/java/io/github/ngspace/hudder/config/ConfigMenu.java
@@ -109,7 +109,7 @@ public class ConfigMenu implements ConfigScreenFactory<Screen> {
 				.setTooltip(Text.translatable("hudder.text.background.tooltip"))
 				.setSaveConsumer(b->config.background=b)
 				.setYesNoTextSupplier(yesno)
-				.setDefaultValue(false)
+				.setDefaultValue(true)
 				.build());
 		text.addEntry(entryBuilder.startBooleanToggle(Text.translatable("hudder.text.shadow"), config.shadow)
 				.setTooltip(Text.translatable("hudder.text.shadow.tooltip"))

--- a/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
@@ -59,7 +59,7 @@ public class MethodHandler {
 		register((c,m,a,t,l,ch,s)->Hudder.log(s[0].asString()),1, TextArg, "log");
 		register((c,m,a,t,l,ch,s)->Hudder.warn(s[0].asString()),1, TextArg, "warn");
 		register((c,m,a,t,l,ch,s)->Hudder.error(s[0].asString()),1, TextArg, "error");
-		register((c,m,a,t,l,ch,s)->{throw new CompileException(s[0].asString());},1, TextArg, "throw");
+		register((c,m,a,t,l,ch,s)->{throw new CompileException(s[0].asString(),l,ch);},1, TextArg, "throw");
 		
 		
 		
@@ -88,7 +88,7 @@ public class MethodHandler {
 				String err='"'+name+"\" only accepts ;"+name+"";
 				for(String str:args)err+=", "+ str;
 				err+=';';
-				throw new CompileException(err);
+				throw new CompileException(err,l,c);
 			}
 			method.invoke(config,meta,compiler,name,l,c,vals);
 		};

--- a/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
@@ -82,8 +82,7 @@ public class MethodHandler {
 	public void register(IMethod method, String... names) {for(String name:names)methods.put(name,method);}
 	
 	public void register(IMethod method, int length, String[] args, String... names) {
-		IMethod newmethod = (config,meta,compiler,name,l,c,vals)->{
-			
+		IMethod newmethod = (config,meta,compiler,name,l,c,vals) -> {
 			if (vals.length<length) {
 				String err='"'+name+"\" only accepts ;"+name+"";
 				for(String str:args)err+=", "+ str;
@@ -93,36 +92,6 @@ public class MethodHandler {
 			method.invoke(config,meta,compiler,name,l,c,vals);
 		};
 		for (String name : names) methods.put(name,newmethod);
-	}
-	
-	@SuppressWarnings("removal")
-	public void register(String method, String[] argtypes, String name) {
-		int[] parameters = new int[argtypes.length];
-		for (int i = 0;i<argtypes.length;i++) {
-			if ("string".equals(argtypes[i])) parameters[i] = 1;
-			else if ("number".equals(argtypes[i])) parameters[i] = 2;
-			else if ("boolean".equals(argtypes[i])) parameters[i] = 3;
-			else if ("string_safe".equals(argtypes[i])) parameters[i] = 4;
-			else if ("number_safe".equals(argtypes[i])) parameters[i] = 5;
-			else if ("boolean_safe".equals(argtypes[i])) parameters[i] = 6;
-		}
-		String errb = '"'+name+"\" only accepts ;"+name+"";
-		for (String arg : argtypes) errb += ", [" + arg + "]";
-		errb+=';';
-		String err = errb;
-		IMethod newmethod = (info,state,comp,type,line,charpos,vals) -> {
-			if (vals.length!=argtypes.length) throw new CompileException(err);
-			for (int i = 0;i<vals.length;i++) {
-				if      (parameters[i]==1) comp.put("arg"+(i+1), vals[i].asString());
-				else if (parameters[i]==2) comp.put("arg"+(i+1), vals[i].asDouble());
-				else if (parameters[i]==3) comp.put("arg"+(i+1), vals[i].asBoolean());
-				else if (parameters[i]==4) comp.put("arg"+(i+1), vals[i].asStringSafe());
-				else if (parameters[i]==5) comp.put("arg"+(i+1), vals[i].asDoubleSafe());
-				else if (parameters[i]==6) comp.put("arg"+(i+1), vals[i].asBooleanSafe());
-			}
-			state.combineWithResult(comp.compile(info, method), false);
-		};
-		methods.put(name,newmethod);
 	}
 	
 	
@@ -149,6 +118,8 @@ public class MethodHandler {
 			else if ("string_safe".equals(argtypes[i])) parameters[i] = 4;
 			else if ("number_safe".equals(argtypes[i])) parameters[i] = 5;
 			else if ("boolean_safe".equals(argtypes[i])) parameters[i] = 6;
+			else if ("array".equals(argtypes[i])) parameters[i] = 7;
+			else if ("any".equals(argtypes[i])) parameters[i] = 8;
 		}
 		String errb = '"'+name+"\" only accepts ;"+name+"";
 		for (String arg : argtypes) errb += ", [" + arg + "]";
@@ -163,6 +134,8 @@ public class MethodHandler {
 				else if (parameters[i]==4) comp.put("arg"+(i+1), vals[i].asStringSafe());
 				else if (parameters[i]==5) comp.put("arg"+(i+1), vals[i].asDoubleSafe());
 				else if (parameters[i]==6) comp.put("arg"+(i+1), vals[i].asBooleanSafe());
+				else if (parameters[i]==7) comp.put("arg"+(i+1), vals[i].asList());
+				else if (parameters[i]==8) comp.put("arg"+(i+1), vals[i].get());
 			}
 			try {
 				state.combineWithResult(comp.compile(info, method), false);

--- a/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/MethodHandler.java
@@ -13,10 +13,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import io.github.ngspace.hudder.Hudder;
-import io.github.ngspace.hudder.compilers.ATextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
-import io.github.ngspace.hudder.compilers.utils.CompileState;
-import io.github.ngspace.hudder.config.ConfigInfo;
 import io.github.ngspace.hudder.methods.methods.DecimalMethods;
 import io.github.ngspace.hudder.methods.methods.GUIMethods;
 import io.github.ngspace.hudder.methods.methods.IMethod;
@@ -41,20 +38,9 @@ public class MethodHandler {
 		
 		
 		//Text and compiling
-		register((i,m,c,type,args)->m.setTextLocation(type,(float) (args.length>0?args[0].asDouble():i.scale)),
+		register((c,m,a,t,l,ch,s)->m.setTextLocation(t,(float) (s.length>0?s[0].asDouble():c.scale)),
 				BOTTOMRIGHT, TOPLEFT, TOPRIGHT, BOTTOMLEFT, MUTE);
 		register(new TextMethod(), "text");
-		
-		// TODO remove this clusterfuck of a method (After 5.0.0)
-		
-		register(new IMethod() {
-			@Override public boolean isDeprecated(String name) {return true;}
-			@Override public void invoke(ConfigInfo info, CompileState m, ATextCompiler a, String t, MethodValue... s)
-					throws CompileException {
-				a.put(s[1].getAbsoluteValue(), Hudder.ins.textRenderer.getWidth(s[0].asString()));
-			}
-		}, 2, new String[] {"[Text]",Var[0]}, "strwidth");
-		
 		
 		
 		//UI
@@ -69,11 +55,11 @@ public class MethodHandler {
 		
 		
 		//Logging and errors
-		register((c,m,a,t,s)->Hudder.ins.player.sendMessage(Text.of(s[0].asString())),1, TextArg, "alert");
-		register((c,m,a,t,s)->Hudder.log(s[0].asString()),1, TextArg, "log");
-		register((c,m,a,t,s)->Hudder.warn(s[0].asString()),1, TextArg, "warn");
-		register((c,m,a,t,s)->Hudder.error(s[0].asString()),1, TextArg, "error");
-		register((c,m,a,t,s)->{throw new CompileException(s[0].asString());},1, TextArg, "throw");
+		register((c,m,a,t,l,ch,s)->Hudder.ins.player.sendMessage(Text.of(s[0].asString())),1, TextArg, "alert");
+		register((c,m,a,t,l,ch,s)->Hudder.log(s[0].asString()),1, TextArg, "log");
+		register((c,m,a,t,l,ch,s)->Hudder.warn(s[0].asString()),1, TextArg, "warn");
+		register((c,m,a,t,l,ch,s)->Hudder.error(s[0].asString()),1, TextArg, "error");
+		register((c,m,a,t,l,ch,s)->{throw new CompileException(s[0].asString());},1, TextArg, "throw");
 		
 		
 		
@@ -96,7 +82,7 @@ public class MethodHandler {
 	public void register(IMethod method, String... names) {for(String name:names)methods.put(name,method);}
 	
 	public void register(IMethod method, int length, String[] args, String... names) {
-		IMethod newmethod = (config,meta,compiler,name,vals)->{
+		IMethod newmethod = (config,meta,compiler,name,l,c,vals)->{
 			
 			if (vals.length<length) {
 				String err='"'+name+"\" only accepts ;"+name+"";
@@ -104,7 +90,7 @@ public class MethodHandler {
 				err+=';';
 				throw new CompileException(err);
 			}
-			method.invoke(config,meta,compiler,name,vals);
+			method.invoke(config,meta,compiler,name,l,c,vals);
 		};
 		for (String name : names) methods.put(name,newmethod);
 	}
@@ -124,7 +110,7 @@ public class MethodHandler {
 		for (String arg : argtypes) errb += ", [" + arg + "]";
 		errb+=';';
 		String err = errb;
-		IMethod newmethod = (info,state,comp,type,vals) -> {
+		IMethod newmethod = (info,state,comp,type,line,charpos,vals) -> {
 			if (vals.length!=argtypes.length) throw new CompileException(err);
 			for (int i = 0;i<vals.length;i++) {
 				if      (parameters[i]==1) comp.put("arg"+(i+1), vals[i].asString());
@@ -150,5 +136,40 @@ public class MethodHandler {
 		IMethod method = methods.get(name.toLowerCase());
 		if (method==null) throw new CompileException("Unknown method " + name);
 		return method;
+	}
+
+
+	@SuppressWarnings("removal")
+	public void register(String method, String[] argtypes, String name, int defline, int defcharpos) {
+		int[] parameters = new int[argtypes.length];
+		for (int i = 0;i<argtypes.length;i++) {
+			if ("string".equals(argtypes[i])) parameters[i] = 1;
+			else if ("number".equals(argtypes[i])) parameters[i] = 2;
+			else if ("boolean".equals(argtypes[i])) parameters[i] = 3;
+			else if ("string_safe".equals(argtypes[i])) parameters[i] = 4;
+			else if ("number_safe".equals(argtypes[i])) parameters[i] = 5;
+			else if ("boolean_safe".equals(argtypes[i])) parameters[i] = 6;
+		}
+		String errb = '"'+name+"\" only accepts ;"+name+"";
+		for (String arg : argtypes) errb += ", [" + arg + "]";
+		errb+=';';
+		String err = errb;
+		IMethod newmethod = (info,state,comp,type,line,charpos,vals) -> {
+			if (vals.length!=argtypes.length) throw new CompileException(err, defline, defcharpos);
+			for (int i = 0;i<vals.length;i++) {
+				if      (parameters[i]==1) comp.put("arg"+(i+1), vals[i].asString());
+				else if (parameters[i]==2) comp.put("arg"+(i+1), vals[i].asDouble());
+				else if (parameters[i]==3) comp.put("arg"+(i+1), vals[i].asBoolean());
+				else if (parameters[i]==4) comp.put("arg"+(i+1), vals[i].asStringSafe());
+				else if (parameters[i]==5) comp.put("arg"+(i+1), vals[i].asDoubleSafe());
+				else if (parameters[i]==6) comp.put("arg"+(i+1), vals[i].asBooleanSafe());
+			}
+			try {
+				state.combineWithResult(comp.compile(info, method), false);
+			} catch (CompileException e) {
+				throw new CompileException(e.getFailureMessage() +"\nMethod threw an error " + type, line, charpos);
+			}
+		};
+		methods.put(name,newmethod);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/methods/MethodValue.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/MethodValue.java
@@ -1,5 +1,7 @@
 package io.github.ngspace.hudder.methods;
 
+import java.util.List;
+
 import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
@@ -20,6 +22,7 @@ public abstract class MethodValue {
 	public abstract int asInt() throws CompileException;
 	public abstract double asDouble() throws CompileException;
 	public abstract boolean asBoolean() throws CompileException;
+	public abstract List<Object> asList() throws CompileException;
 	
 	/**
 	 * @deprecated to encourage type safety, will be removed in the future.

--- a/src/main/java/io/github/ngspace/hudder/methods/elements/TextElement.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/elements/TextElement.java
@@ -12,13 +12,13 @@ public class TextElement extends AUIElement {
 	public final int x;
 	public final int y;
 	public final int color;
-	public final int backgroundcolor;
+	public final long backgroundcolor;
 	public final float scale;
 	public final boolean shadow;
 	public final boolean background;
 
 	public TextElement(int x, int y, String text, float scale, int color, boolean shadow,boolean background,
-			int backgroundcolor) {
+			long backgroundcolor) {
 		this.text = text;
 		this.x = x;
 		this.y = y;

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/DecimalMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/DecimalMethods.java
@@ -17,10 +17,10 @@ public class DecimalMethods implements IMethod {
 		return "Use truncate function";
 	}
 	@Override
-	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, MethodValue... args)
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... args)
 			throws CompileException {
 		if (args.length!=2)
-			throw new CompileException("\""+type+"\" only accepts ;"+type+",[Variable],[max decimal point];");
+			throw new CompileException("\""+type+"\" only accepts ;"+type+",[Variable],[max decimal point];", line, charpos);
 		double point = args[1].asDouble();
 		double d /*hehe double d*/ = args[0].asDouble();
 		double pow = Math.pow(10, point);

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/GUIMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/GUIMethods.java
@@ -10,8 +10,8 @@ import io.github.ngspace.hudder.methods.elements.GameHudElement.GuiType;
 
 public class GUIMethods implements IMethod {
 	@Override
-	public void invoke(ConfigInfo conf, CompileState meta, ATextCompiler comp, String type, MethodValue... s) throws CompileException {
-		if (s.length!=2) throw new CompileException("\""+type+"\" only accepts ;"+type+", [X], [Y];");
+	public void invoke(ConfigInfo conf, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... s) throws CompileException {
+		if (s.length!=2) throw new CompileException("\""+type+"\" only accepts ;"+type+", [X], [Y];", line, charpos);
 		int x = s[0].asInt();
 		int y = s[1].asInt();
 		GuiType guiType = switch (type) {

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/IMethod.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/IMethod.java
@@ -24,6 +24,6 @@ public interface IMethod {
 	 * @param args - the parameters supplied to this method
 	 * @throws CompileException - if the method is not called properly or is unable to execute.
 	 */
-	public void invoke(ConfigInfo config, CompileState meta, ATextCompiler compiler, String method, MethodValue... args)
-			throws CompileException;
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos,
+			MethodValue... args) throws CompileException;
 }

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/InventoryInformationMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/InventoryInformationMethods.java
@@ -13,7 +13,7 @@ public class InventoryInformationMethods implements IMethod {
 	// TODO replace this with a proper function (after version 5.0.0)
 	
 	@Override
-	public void invoke(ConfigInfo config, CompileState m, ATextCompiler c, String type, MethodValue... s) throws CompileException {
+	public void invoke(ConfigInfo config, CompileState m, ATextCompiler c, String type, int line, int charpos, MethodValue... s) throws CompileException {
 		ItemStack stack = Hudder.ins.player.getInventory().getStack(s[0].asInt());
 		Object value = switch (type) {
 			case "name"         ->stack.getName().getString();

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/InventoryInformationMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/InventoryInformationMethods.java
@@ -10,7 +10,12 @@ import net.minecraft.item.ItemStack;
 
 public class InventoryInformationMethods implements IMethod {
 	
-	// TODO replace this with a proper function (after version 5.0.0)
+	@Override public boolean isDeprecated(String name) {return true;}
+	
+	@Override
+	public String getDeprecationWarning(String name) {
+		return name + " is Deprecated and will be removed, use the item" +name + "([Slot number]) function instead!";
+	}
 	
 	@Override
 	public void invoke(ConfigInfo config, CompileState m, ATextCompiler c, String type, int line, int charpos, MethodValue... s) throws CompileException {

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/ItemStackMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/ItemStackMethods.java
@@ -15,13 +15,13 @@ import net.minecraft.util.Identifier;
 
 public class ItemStackMethods implements IMethod {
 	@Override
-	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, MethodValue... args) throws CompileException {
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... args) throws CompileException {
 		int offset = "slot".equals(type)||"item".equals(type) ? 1:0;
 		if (args.length<2+offset) {
 			throw new CompileException("\""+type+"\" only accepts ;"+type
 				+("slot".equals(type)?",[slot]":"")
 				+("item".equals(type)?",[item]":"")
-				+",[x],[y],<scale>,<show count>;");
+				+",[x],[y],<scale>,<show count>;", line, charpos);
 		}
 		double x = args[0+offset].asDouble();
 		double y = args[1+offset].asDouble();

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/LoadMethod.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/LoadMethod.java
@@ -14,17 +14,20 @@ import io.github.ngspace.hudder.util.HudFileUtils;
 public class LoadMethod implements IMethod {
 	@SuppressWarnings("removal")
 	@Override
-	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, MethodValue... args) throws CompileException {
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... args) throws CompileException {
 		if (args.length<1)
 			throw new CompileException("\""+type+"\" only accepts ;"+type+",[file],<text>,<compiler>;");
+		String file = args[0].asStringSafe();
 		try {
 			boolean AddText = (args.length<2 || args[1].asBoolean()) || type.equals("add");
 			ATextCompiler ecompiler=(args.length>2?Compilers.getCompilerFromName(args[2].asString()):comp);
 			for (var i : Hudder.precomplistners) i.accept(ecompiler);
-			meta.combineWithResult(ecompiler.compile(ci, HudFileUtils.getFile(args[0].asStringSafe())), AddText);
+			meta.combineWithResult(ecompiler.compile(ci, HudFileUtils.getFile(file)), AddText);
 			for (var i : Hudder.postcomplistners) i.accept(ecompiler);
-		} catch (ReflectiveOperationException | IllegalArgumentException | SecurityException | IOException e) {
+		} catch (ReflectiveOperationException | IOException e) {
 			throw new CompileException(e.getLocalizedMessage());
+		} catch (CompileException e) {
+			throw new CompileException(e.getFailureMessage() +"\nRun Failed for hud file " + file, line, charpos);
 		}
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/StringMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/StringMethods.java
@@ -19,7 +19,7 @@ public class StringMethods implements IMethod {
 	}
 
 	@Override
-	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, MethodValue... args) throws CompileException {
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... args) throws CompileException {
 		try {
 			switch (type) {
 				case "concat": {
@@ -41,7 +41,7 @@ public class StringMethods implements IMethod {
 					try {
 						comp.put(args[3].getAbsoluteValue(),str1.substring(start,end));
 					} catch (IndexOutOfBoundsException e) {
-						throw new CompileException(e.getLocalizedMessage());
+						throw new CompileException(e.getLocalizedMessage(), line, charpos);
 					}
 					break;
 				}
@@ -53,8 +53,8 @@ public class StringMethods implements IMethod {
 					+(type.equals("concat")         ?",[string],[string],[result variable name]" :"")
 					+(type.equals("multiplystring") ?",[string],[amount],[result variable name]" :"")
 					+(type.equals("substring") ?",[string],[start],[end],[result variable name]" :"")
-					+ ";");
-		} catch (Exception e) {throw new CompileException(e.getLocalizedMessage());}
+					+ ";", line, charpos);
+		} catch (Exception e) {throw new CompileException(e.getLocalizedMessage(), line, charpos);}
 	}
 
 }

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/TextMethod.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/TextMethod.java
@@ -10,9 +10,9 @@ import io.github.ngspace.hudder.methods.elements.TextElement;
 public class TextMethod implements IMethod {
 
 	@Override
-	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, MethodValue... args) throws CompileException {
+	public void invoke(ConfigInfo ci, CompileState meta, ATextCompiler comp, String type, int line, int charpos, MethodValue... args) throws CompileException {
 		if (args.length<3) throw new CompileException(
-				"\""+type+"\" only accepts ;"+type+",[x],[y],[text],<scale>,<color>,<shadow>,<bg>,<bgcolor>;");
+				"\""+type+"\" only accepts ;"+type+",[x],[y],[text],<scale>,<color>,<shadow>,<bg>,<bgcolor>;", line, charpos);
 		try {
 			String text = args[2].asString();
 			float scale = (float) (args.length>3 ? args[3].asDouble() : ci.scale);
@@ -22,11 +22,11 @@ public class TextMethod implements IMethod {
 
 			int color = args.length>4 ? args[4].asInt() : ci.color;
 			boolean shadow = args.length>5 ? args[5].asBoolean():ci.shadow;
-			int bgcolor = args.length>7 ? args[7].asInt() : ci.backgroundcolor;
 			boolean bg = args.length>6 ? args[6].asBoolean():ci.background;
+			double bgcolor = args.length>7 ? args[7].asDouble() : ci.backgroundcolor;
 			
-			meta.elements.add(new TextElement(x,y,text,scale,color,shadow,bg,bgcolor));
-		} catch (Exception e) {throw new CompileException(e.getLocalizedMessage());}
+			meta.elements.add(new TextElement(x,y,text,scale,color,shadow,bg,(long) bgcolor));
+		} catch (Exception e) {throw new CompileException(e.getLocalizedMessage(), line, charpos);}
 	}
 
 }

--- a/src/main/java/io/github/ngspace/hudder/methods/methods/TexturesMethods.java
+++ b/src/main/java/io/github/ngspace/hudder/methods/methods/TexturesMethods.java
@@ -13,7 +13,7 @@ import net.minecraft.util.Identifier;
 
 public class TexturesMethods implements IMethod {
 
-	@Override public void invoke(ConfigInfo i, CompileState m, ATextCompiler c, String type, MethodValue... s) throws CompileException {
+	@Override public void invoke(ConfigInfo i, CompileState m, ATextCompiler c, String type, int line, int charpos, MethodValue... s) throws CompileException {
 		switch (type) {
 			case "image","png":
         		try {
@@ -23,7 +23,7 @@ public class TexturesMethods implements IMethod {
 					HudFileUtils.getAndRegisterImage(s[0].asString(),id);
 	        		m.elements.add(new TextureElement(id,s[1].asInt(),s[2].asInt(),s[3].asInt(),s[4].asInt()));
 				} catch (IOException e) {
-					throw new CompileException(e.getLocalizedMessage());
+					throw new CompileException(e.getLocalizedMessage(), line, charpos);
 				}
 				break;	
 			case "texture":

--- a/src/main/java/io/github/ngspace/hudder/util/HudderUtils.java
+++ b/src/main/java/io/github/ngspace/hudder/util/HudderUtils.java
@@ -8,12 +8,13 @@ public class HudderUtils {private HudderUtils() {}
 		if (strtoprocess.isBlank()) return new String[0];
 		
 		int parentheses = 0;
+		int squareparentheses = 0;
 
 		StringBuilder parameterBuilder = new StringBuilder();
 		String[] tokenizedParemeters = new String[0];
 		for (int i = 0;i<strtoprocess.length();i++) {
 			char c = strtoprocess.charAt(i);
-			if (c==','&&parentheses==0) {
+			if (c==','&&parentheses==0&&squareparentheses==0) {
 				tokenizedParemeters = addToArray(tokenizedParemeters, parameterBuilder.toString());
 				parameterBuilder.setLength(0);
 				continue;
@@ -43,6 +44,8 @@ public class HudderUtils {private HudderUtils() {}
 			}
 			if (c=='(') parentheses++;
 			if (c==')') parentheses--;
+			if (c=='[') squareparentheses++;
+			if (c==']') squareparentheses--;
 			
 			parameterBuilder.append(c);
 		}

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/AV2Compiler.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/AV2Compiler.java
@@ -24,13 +24,10 @@ public abstract class AV2Compiler extends AVarTextCompiler {
 	protected Map<String, Object> tempVariables = new HashMap<String, Object>();
 	
 	public void setTempVariable(String key, Object value) {tempVariables.put(key, value);}
-	public Object getTempVariable(String key) {return tempVariables.get(key);}// TODO finish this shit.
+	public Object getTempVariable(String key) {return tempVariables.get(key);}
 	
 	public AV2Value getV2Value(V2Runtime runtime, String string, int line, int charpos) throws CompileException {
 		return V2ValueParser.of(runtime, string, this, line, charpos);
-	}
-	public AV2Value getV2Value(V2Runtime runtime, String string) throws CompileException {
-		return getV2Value(runtime, string, -1, -1);
 	}
 	
 	@Override public final CompileResult compile(ConfigInfo info, String text) throws CompileException {
@@ -40,6 +37,7 @@ public abstract class AV2Compiler extends AVarTextCompiler {
 	}
 	public abstract V2Runtime buildRuntime(ConfigInfo info, String text, CharPosition charPosition) throws CompileException;
 	
-	@Override
-	public void reset() {runtimes.clear();variables.clear();tempVariables.clear();}
+	public void putTemp(String key, Object value) {
+		tempVariables.put(key, value);
+	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/AV2Compiler.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/AV2Compiler.java
@@ -3,28 +3,43 @@ package io.github.ngspace.hudder.v2runtime;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.github.ngspace.hudder.Hudder;
 import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.compilers.utils.CompileResult;
 import io.github.ngspace.hudder.config.ConfigInfo;
+import io.github.ngspace.hudder.methods.MethodHandler;
 import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 import io.github.ngspace.hudder.v2runtime.values.V2ValueParser;
 
 public abstract class AV2Compiler extends AVarTextCompiler {
 	
-	public Map<String, V2Runtime> runtimes = new HashMap<String, V2Runtime>();
-	
-	public AV2Value getV2Value(V2Runtime runtime, String string) throws CompileException {
-		return V2ValueParser.of(runtime, string, this);
+	protected AV2Compiler() {
+		Hudder.addPreCompilerListener(c -> {if (this==c) tempVariables.clear();});
 	}
 	
-	@Override public CompileResult compile(ConfigInfo info, String text) throws CompileException {
+	public Map<String, V2Runtime> runtimes = new HashMap<String, V2Runtime>();
+	public final MethodHandler methodHandler = new MethodHandler();
+	
+	protected Map<String, Object> tempVariables = new HashMap<String, Object>();
+	
+	public void setTempVariable(String key, Object value) {tempVariables.put(key, value);}
+	public Object getTempVariable(String key) {return tempVariables.get(key);}// TODO finish this shit.
+	
+	public AV2Value getV2Value(V2Runtime runtime, String string, int line, int charpos) throws CompileException {
+		return V2ValueParser.of(runtime, string, this, line, charpos);
+	}
+	public AV2Value getV2Value(V2Runtime runtime, String string) throws CompileException {
+		return getV2Value(runtime, string, -1, -1);
+	}
+	
+	@Override public final CompileResult compile(ConfigInfo info, String text) throws CompileException {
 		V2Runtime runtime = runtimes.get(text);
-		if (runtime==null) runtimes.put(text, (runtime=buildRuntime(info,text)));
+		if (runtime==null) runtimes.put(text, (runtime=buildRuntime(info,text, new CharPosition(-1, -1))));
 		return runtime.execute().toResult();
 	}
-	public abstract V2Runtime buildRuntime(ConfigInfo info, String text) throws CompileException;
+	public abstract V2Runtime buildRuntime(ConfigInfo info, String text, CharPosition charPosition) throws CompileException;
 	
 	@Override
-	public void reset() {runtimes.clear();variables.clear();}
+	public void reset() {runtimes.clear();variables.clear();tempVariables.clear();}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/V2Runtime.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/V2Runtime.java
@@ -4,13 +4,11 @@ import java.util.Arrays;
 
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.compilers.utils.CompileState;
-import io.github.ngspace.hudder.methods.MethodHandler;
 import io.github.ngspace.hudder.v2runtime.functions.V2FunctionHandler;
 import io.github.ngspace.hudder.v2runtime.runtime_elements.AV2RuntimeElement;
 
 public class V2Runtime {
 	
-	public final MethodHandler methodHandler = new MethodHandler();
 	public final V2FunctionHandler functionHandler = new V2FunctionHandler();
 	
 	AV2RuntimeElement[] elements = new AV2RuntimeElement[0];

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/ArrayV2Function.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/ArrayV2Function.java
@@ -1,0 +1,19 @@
+package io.github.ngspace.hudder.v2runtime.functions;
+
+import java.util.ArrayList;
+
+import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.V2Runtime;
+import io.github.ngspace.hudder.v2runtime.values.AV2Value;
+
+public class ArrayV2Function implements IV2Function {
+	
+	@Override
+	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos)
+			throws CompileException {
+		var lst = new ArrayList<Object>();
+		for (char c : args[0].asString().toCharArray()) lst.add(c);
+		return lst;
+	}
+	
+}

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/IV2Function.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/IV2Function.java
@@ -5,5 +5,5 @@ import io.github.ngspace.hudder.v2runtime.V2Runtime;
 import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 
 public interface IV2Function {
-	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args) throws CompileException;
+	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos) throws CompileException;
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/LengthV2Function.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/LengthV2Function.java
@@ -1,26 +1,18 @@
 package io.github.ngspace.hudder.v2runtime.functions;
 
+import java.util.Collection;
+
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
 import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 
-public class DoubleV2Function implements IV2Function {
-	
+public class LengthV2Function implements IV2Function {
+
 	@Override public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos)
 			throws CompileException {
 		Object value = args[0].get();
-		
-		switch (value) {
-			case Number num:
-				return num.doubleValue();
-			case String str:
-				return Double.parseDouble(str);
-			case Boolean bool:
-				return Boolean.TRUE.equals(bool)?1d:0d;
-			default:
-				if (value==null) throw new CompileException("Value of variable is null!", line, charpos);
-				return Double.parseDouble(value.toString());
-		}
+		if (value instanceof Collection<?> c) return c.size();
+		return args[0].asString().length();
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/RngV2Function.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/RngV2Function.java
@@ -11,12 +11,9 @@ public class RngV2Function implements IV2Function {
 	
 	Random random = new Random();
 	HashMap<Integer, Random> randoms = new HashMap<Integer, Random>();
-	
-	@Override
-	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args) throws CompileException {
-		if (args.length<2) throw new CompileException("Too little parameters for "+functionName+"!");
-		if (args.length>3) throw new CompileException("Too many parameters for "+functionName+"!");
-		
+
+	@Override public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos)
+			throws CompileException {
 		return (args.length==3? new Random(args[2].asInt()) : random).nextDouble(args[0].asDouble(),args[1].asDouble());
 	}
 	

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/StringV2Function.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/StringV2Function.java
@@ -1,21 +1,29 @@
 package io.github.ngspace.hudder.v2runtime.functions;
 
+import java.util.List;
+
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.methods.MethodValue;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
 import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 
 public class StringV2Function implements IV2Function {
-	
-	@Override
-	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args) throws CompileException {
-		if (args.length<1) throw new CompileException("Too little parameters for "+functionName+"!");
-		if (args.length>2) throw new CompileException("Too many parameters for "+functionName+"!");
+
+	@Override public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos)
+			throws CompileException {
 		
 		Object value = args[0].get();
 		
 		if (args.length==2&&(boolean) args[1].get()&&value instanceof Number num)
 			return MethodValue.cleanDouble(num.doubleValue());
+		if (value instanceof List<?> s) {
+			StringBuilder b = new StringBuilder();
+			for (var v : s) {
+//				System.out.println(v.toString());
+				b.append(v);
+			}
+			return b.toString();
+		}
 		return value.toString();
 	}
 	

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/TestFunction.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/TestFunction.java
@@ -6,8 +6,8 @@ import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 
 public class TestFunction implements IV2Function {
 
-	@Override
-	public Object execute(V2Runtime runtime, String functionName, AV2Value[] args) throws CompileException {
+	@Override public Object execute(V2Runtime runtime, String functionName, AV2Value[] args, int line, int charpos)
+			throws CompileException {
 		return args[0].asString() + args[1].asString();
 	}
 	

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/functions/V2FunctionHandler.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/functions/V2FunctionHandler.java
@@ -11,49 +11,67 @@ public class V2FunctionHandler {
 	private Map<String, IV2Function> functions = new HashMap<String,IV2Function>();
 	
 	public V2FunctionHandler() {
-		if (Hudder.IS_DEBUG) register(new TestFunction(), "test");
+		if (Hudder.IS_DEBUG) register(new TestFunction(), 2, "test");
 		
 		//Type casting
 		
-		register(new DoubleV2Function(), 1, "int", "num", "number", "double"); // Int
-		register(new StringV2Function(), "str", "string"); // Str
+		register(new DoubleV2Function(), 1, "int", "num", "number", "double");
+		register(new StringV2Function(), 1, 2, "str", "string");
+		register(new ArrayV2Function(), 1, "array");
 		
 		//String manipulation
 
-		register((r,n,args) -> args[0].asString() + args[1].asString(), 2, "concat");// Concat
-		register((r,n,args) -> args[0].asString().substring(args[1].asInt(),args[2].asInt()),3,"substring");// Substring
-		register((r,n,args) -> args[0].asString().repeat(args[1].asInt()),2, "multiplystring", "repeat");// Repeat string
-		register((r,n,args) -> args[0].asString().length(), 1, "length");// Length
+		register((r,n,args,l,c) -> args[0].asString() + args[1].asString(), 2, "concat");
+		register((r,n,args,l,c) -> args[0].asString().substring(args[1].asInt(),args[2].asInt()),3,"substring");
+		register((r,n,args,l,c) -> args[0].asString().repeat(args[1].asInt()),2, "multiplystring", "repeat");
 		
 		//Math
 		
-		register(new RngV2Function(), "rng", "random"); // Rng
+		register(new RngV2Function(), 2, 3, "rng", "random"); // Rng
 
-		register((r,n,args) -> Math.abs  (args[0].asDouble()) ,1, "abs"    );// Abs
-		register((r,n,args) -> Math.floor(args[0].asDouble()) ,1, "floor"  );// Floor
-		register((r,n,args) -> Math.ceil (args[0].asDouble()) ,1, "ceiling");// Ceiling
+		register((r,n,args,l,c) -> Math.abs  (args[0].asDouble()) ,1, "abs"    );
+		register((r,n,args,l,c) -> Math.floor(args[0].asDouble()) ,1, "floor"  );
+		register((r,n,args,l,c) -> Math.ceil (args[0].asDouble()) ,1, "ceiling");
 		
-		register((r,n,args) -> Math.sin(args[0].asDouble()) ,1, "sin" );// Sin
-		register((r,n,args) -> Math.cos(args[0].asDouble()) ,1, "cos" );// Cos
-		register((r,n,args) -> Math.tan(args[0].asDouble()) ,1, "tan" );// Tan
+		register((r,n,args,l,c) -> Math.sin(args[0].asDouble()) ,1, "sin" );
+		register((r,n,args,l,c) -> Math.cos(args[0].asDouble()) ,1, "cos" );
+		register((r,n,args,l,c) -> Math.tan(args[0].asDouble()) ,1, "tan" );
 		
-		register((r,n,args) -> Math.asin(args[0].asDouble()),1, "asin");// Asin
-		register((r,n,args) -> Math.acos(args[0].asDouble()),1, "acos");// Acos
-		register((r,n,args) -> Math.atan(args[0].asDouble()),1, "atan");// Atan
+		register((r,n,args,l,c) -> Math.asin(args[0].asDouble()),1, "asin");
+		register((r,n,args,l,c) -> Math.acos(args[0].asDouble()),1, "acos");
+		register((r,n,args,l,c) -> Math.atan(args[0].asDouble()),1, "atan");
 		
-		register((r,n,args) -> Math.sqrt(args[0].asDouble()),1, "sqrt");// Sqrt
+		register((r,n,args,l,c) -> Math.sqrt(args[0].asDouble()),1, "sqrt");
 		
-		register((r,n,args) -> Math.pow(args[0].asDouble(),args[1].asDouble()), 2, "pow");// Pow
-		register((r,n,args) -> Math.min(args[0].asDouble(),args[1].asDouble()), 2, "min");// Min
-		register((r,n,args) -> Math.max(args[0].asDouble(),args[1].asDouble()), 2, "max");// Max
+		register((r,n,args,l,c) -> Math.pow(args[0].asDouble(),args[1].asDouble()), 2, "pow");
+		register((r,n,args,l,c) -> Math.min(args[0].asDouble(),args[1].asDouble()), 2, "min");
+		register((r,n,args,l,c) -> Math.max(args[0].asDouble(),args[1].asDouble()), 2, "max");
 		
-		register((r,n,args) -> Math.floor(args[0].asDouble()*Math.pow(10, args[1].asInt()))
-				/Math.pow(10, args[1].asInt()),2,"truncate");// Truncate
+		register((r,n,args,l,c) -> Math.floor(args[0].asDouble()*Math.pow(10, args[1].asInt()))
+				/Math.pow(10, args[1].asInt()),2,"truncate");
+		
+		//Inventory management
+
+		register((r,n,args,l,c)->Hudder.ins.player.getInventory().getStack(args[0].asInt()).getName(),1,"itemname");
+		register((r,n,args,l,c)->Hudder.ins.player.getInventory().getStack(args[0].asInt()).getCount(),1,"itemcount");
+		
+		
+		register((r,n,args,l,c)->{
+			var stack = Hudder.ins.player.getInventory().getStack(args[0].asInt());
+			return stack.getMaxDamage()-stack.getDamage();
+		},1,"itemdurability");
+		
+		
+		register((r,n,args,l,c)->Hudder.ins.player.getInventory().getStack(args[0].asInt()).getMaxDamage(),1,
+				"itemmaxdurability");
+		register((r,n,args,l,c)->Hudder.ins.player.getInventory().getStack(args[0].asInt()).getMaxCount(),1,
+				"itemmaxcount");
 		
 		// Misc
 		
-		register((r,n,args) -> HudFileUtils.exists(args[0].asString()), 1, "exists");// Exists
-		register((r,n,args) -> Hudder.ins.textRenderer.getWidth(args[0].asString()), 1, "strwidth");// Strwidth
+		register((r,n,args,l,c) -> HudFileUtils.exists(args[0].asString()), 1, "exists");
+		register((r,n,args,l,c) -> Hudder.ins.textRenderer.getWidth(args[0].asString()), 1, "strwidth");
+		register(new LengthV2Function(), 1, "length");// Length
 		
 	}
 
@@ -62,12 +80,15 @@ public class V2FunctionHandler {
 	}
 
 	public void register(IV2Function function, int length, String... names) {
-		IV2Function expandedFunction = (runtime, name, args) -> {
-			if (args.length<length) throw new CompileException("Too little parameters for "+name+"!");
-			if (args.length>length) throw new CompileException("Too many parameters for "+name+"!");
-			return function.execute(runtime, name, args);
+		register(function,length,length, names);
+	}
+	public void register(IV2Function function, int minlength, int maxlength, String... names) {
+		IV2Function expandedFunction = (runtime, name, args, line, charpos) -> {
+			if (args.length<minlength) throw new CompileException("Too little parameters for "+name+"!",line,charpos);
+			if (args.length>maxlength) throw new CompileException("Too many parameters for "+name+"!",line,charpos);
+			return function.execute(runtime, name, args,line,charpos);
 		};
-		for(String name:names) functions.put(name,expandedFunction);
+		register(expandedFunction,names);
 	}
 	
 	public IV2Function getFunction(String name) {

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/BasicConditionV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/BasicConditionV2RuntimeElement.java
@@ -19,7 +19,8 @@ public class BasicConditionV2RuntimeElement extends AV2RuntimeElement {
 	AVarTextCompiler compiler;
 	ConfigInfo info;
 	boolean hasFinalElse;
-	public BasicConditionV2RuntimeElement(String[] condArgs, AV2Compiler compiler, ConfigInfo info, V2Runtime runtime) {
+	public BasicConditionV2RuntimeElement(String[] condArgs, AV2Compiler compiler, ConfigInfo info, V2Runtime runtime,
+			int line, int charpos) {
 		this.compiler = compiler;
 		this.info = info;
 		
@@ -28,11 +29,11 @@ public class BasicConditionV2RuntimeElement extends AV2RuntimeElement {
 		for (int i = 0;i<condArgs.length;i++) {
 			String str = condArgs[i];
 			if (hasFinalElse&&i==condArgs.length-1) {
-				results = addToArray(results, compiler.getV2Value(runtime, str));
+				results = addToArray(results, compiler.getV2Value(runtime, str,line,charpos));
 				break;
 			}
-			if (i%2==0) conditions = addToArray(conditions, compiler.getV2Value(runtime, str));
-			else results = addToArray(results, compiler.getV2Value(runtime, str));
+			if (i%2==0) conditions = addToArray(conditions, compiler.getV2Value(runtime, str,line,charpos));
+			else results = addToArray(results, compiler.getV2Value(runtime, str,line,charpos));
 		}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/IfV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/IfV2RuntimeElement.java
@@ -1,5 +1,6 @@
 package io.github.ngspace.hudder.v2runtime.runtime_elements;
 
+import io.github.ngspace.hudder.compilers.ATextCompiler.CharPosition;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.compilers.utils.CompileState;
 import io.github.ngspace.hudder.config.ConfigInfo;
@@ -10,21 +11,17 @@ import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 public class IfV2RuntimeElement extends AV2RuntimeElement {
 
 	private AV2Value condition;
-	private ConfigInfo info;
-	private String cmds;
-	private AV2Compiler compiler;
+	private V2Runtime compiledRuntime;
 
-	public IfV2RuntimeElement(ConfigInfo info, String condition, String cmds, AV2Compiler compiler, V2Runtime runtime) throws CompileException {
-		this.condition = compiler.getV2Value(runtime, condition);
-		this.cmds = cmds;
-		this.info = info;
-		this.compiler = compiler;
+	public IfV2RuntimeElement(ConfigInfo info, String condition, String cmds, AV2Compiler compiler, V2Runtime runtime, CharPosition charPosition) throws CompileException {
+		this.condition = compiler.getV2Value(runtime, condition, charPosition.line, charPosition.charpos);
+		this.compiledRuntime = compiler.buildRuntime(info, cmds, new CharPosition(charPosition.line, 1));
 	}
 	
 	@Override
 	public void execute(CompileState meta, StringBuilder builder) throws CompileException {
-		boolean condr = condition.asBoolean();
-		if(condr) meta.combineWithResult(compiler.compile(info, cmds), false);
+		if(condition.asBoolean())
+			meta.combineWithResult(compiledRuntime.execute().toResult(), false);
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/MethodV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/MethodV2RuntimeElement.java
@@ -30,7 +30,7 @@ public class MethodV2RuntimeElement extends AV2RuntimeElement {
 		type = args[0];
 		for (int i = 1;i<args.length;i++) {
 			values = Arrays.copyOf(values, values.length+1);
-			values[values.length-1] = compiler.getV2Value(runtime, args[i]);
+			values[values.length-1] = compiler.getV2Value(runtime, args[i], line, charpos);
 		}
 		method = compiler.methodHandler.getMethodFromName(type);
 		if (method.isDeprecated(type)) {

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/MethodV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/MethodV2RuntimeElement.java
@@ -21,8 +21,10 @@ public class MethodV2RuntimeElement extends AV2RuntimeElement {
 	private AV2Compiler compiler;
 	private ConfigInfo info;
 	private IMethod method;
+	private int line;
+	private int charpos;
 
-	public MethodV2RuntimeElement(String[] args, AV2Compiler compiler, ConfigInfo info, V2Runtime runtime) throws CompileException {
+	public MethodV2RuntimeElement(String[] args, AV2Compiler compiler, ConfigInfo info, V2Runtime runtime, int line, int charpos) throws CompileException {
 		this.compiler = compiler;
 		this.info = info;
 		type = args[0];
@@ -30,13 +32,15 @@ public class MethodV2RuntimeElement extends AV2RuntimeElement {
 			values = Arrays.copyOf(values, values.length+1);
 			values[values.length-1] = compiler.getV2Value(runtime, args[i]);
 		}
-		method = runtime.methodHandler.getMethodFromName(type);
+		method = compiler.methodHandler.getMethodFromName(type);
 		if (method.isDeprecated(type)) {
 			Hudder.showWarningToast(MinecraftClient.getInstance(), Text.literal(type+" method is Deprecated!")
 					.formatted(Formatting.BOLD), Text.literal("\u00A7a" + method.getDeprecationWarning(type)));
 		}
+		this.line = line;
+		this.charpos = charpos;
 	}
 	@Override public void execute(CompileState meta, StringBuilder builder) throws CompileException {
-		method.invoke(info, meta, compiler, type, values);
+		method.invoke(info, meta, compiler, type, line, charpos, values);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/VariableV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/VariableV2RuntimeElement.java
@@ -11,9 +11,9 @@ public class VariableV2RuntimeElement extends AV2RuntimeElement {
 	final AV2Value value;
 	final AV2Compiler compiler;
 	
-	public VariableV2RuntimeElement(String value, AV2Compiler compiler, V2Runtime runtime) throws CompileException {
+	public VariableV2RuntimeElement(String value, AV2Compiler compiler, V2Runtime runtime, int line, int charpos) throws CompileException {
 		this.compiler = compiler;
-		this.value = compiler.getV2Value(runtime, value);
+		this.value = compiler.getV2Value(runtime, value, line, charpos);
 	}
 
 	@Override public void execute(CompileState meta, StringBuilder builder) throws CompileException {

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/WhileV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/WhileV2RuntimeElement.java
@@ -12,10 +12,14 @@ public class WhileV2RuntimeElement extends AV2RuntimeElement {
 	
 	private AV2Value condition;
 	private V2Runtime compiledRuntime;
+	private int line;
+	private int charpos;
 
 	public WhileV2RuntimeElement(ConfigInfo info, String condition, String cmds, AV2Compiler compiler, V2Runtime runtime, CharPosition charPosition) throws CompileException {
 		this.condition = compiler.getV2Value(runtime, condition, charPosition.line, charPosition.charpos);
 		this.compiledRuntime = compiler.buildRuntime(info, cmds, new CharPosition(charPosition.line, 1));
+		this.line = charPosition.line;
+		this.charpos = charPosition.charpos;
 	}
 	
 	@Override
@@ -23,7 +27,7 @@ public class WhileV2RuntimeElement extends AV2RuntimeElement {
 		short s = 32767;
 		while(condition.asBoolean()) {
 			s--;
-			if (s==0) throw new CompileException("While loop limited to 32767");
+			if (s==0) throw new CompileException("While loop limited to 32767",line,charpos);
 			meta.combineWithResult(compiledRuntime.execute().toResult(), false);
 		}
 	}

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/WhileV2RuntimeElement.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/runtime_elements/WhileV2RuntimeElement.java
@@ -1,5 +1,6 @@
 package io.github.ngspace.hudder.v2runtime.runtime_elements;
 
+import io.github.ngspace.hudder.compilers.ATextCompiler.CharPosition;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.compilers.utils.CompileState;
 import io.github.ngspace.hudder.config.ConfigInfo;
@@ -10,15 +11,11 @@ import io.github.ngspace.hudder.v2runtime.values.AV2Value;
 public class WhileV2RuntimeElement extends AV2RuntimeElement {
 	
 	private AV2Value condition;
-	private ConfigInfo info;
-	private String cmds;
-	private AV2Compiler compiler;
+	private V2Runtime compiledRuntime;
 
-	public WhileV2RuntimeElement(ConfigInfo info, String condition, String cmds, AV2Compiler compiler, V2Runtime runtime) throws CompileException {
-		this.condition = compiler.getV2Value(runtime, condition);
-		this.cmds = cmds;
-		this.info = info;
-		this.compiler = compiler;
+	public WhileV2RuntimeElement(ConfigInfo info, String condition, String cmds, AV2Compiler compiler, V2Runtime runtime, CharPosition charPosition) throws CompileException {
+		this.condition = compiler.getV2Value(runtime, condition, charPosition.line, charPosition.charpos);
+		this.compiledRuntime = compiler.buildRuntime(info, cmds, new CharPosition(charPosition.line, 1));
 	}
 	
 	@Override
@@ -27,7 +24,7 @@ public class WhileV2RuntimeElement extends AV2RuntimeElement {
 		while(condition.asBoolean()) {
 			s--;
 			if (s==0) throw new CompileException("While loop limited to 32767");
-			meta.combineWithResult(compiler.compile(info, cmds), false);
+			meta.combineWithResult(compiledRuntime.execute().toResult(), false);
 		}
 	}
 	

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/AV2Value.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/AV2Value.java
@@ -1,10 +1,11 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import java.util.List;
 import java.util.Objects;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.methods.MethodValue;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public abstract class AV2Value extends MethodValue {
 	/**
@@ -37,17 +38,13 @@ public abstract class AV2Value extends MethodValue {
 		if (val1 instanceof Number num) {
 			dou1 = num.doubleValue();
 			boolean otherhasval = other.hasValue();
-			if (!otherhasval) {
-				dou2 = other.asDoubleSafe();
-			}
+			if (!otherhasval) dou2 = other.asDoubleSafe();
 			if (val2 instanceof Number||!otherhasval) areNums = true;
 		}
 		if (val2 instanceof Number num) {
 			dou2 = num.doubleValue();
 			boolean otherhasval = hasValue();
-			if (!otherhasval) {
-				dou1 = asDoubleSafe();
-			}
+			if (!otherhasval)  dou1 = asDoubleSafe();
 			if (val1 instanceof Number||!otherhasval) areNums = true;
 		}
 		return switch (comparisonOperator) {
@@ -84,10 +81,18 @@ public abstract class AV2Value extends MethodValue {
 		if (get instanceof String b) return b;
 		throw new CompileException(invalidTypeMessage("String", value, get), line, charpos);
 	}
+	@SuppressWarnings("unchecked")
+	@Override public List<Object> asList() throws CompileException {
+		Object get = get();
+		if (get instanceof List<?> b) return (List<Object>) b;
+		throw new CompileException(invalidTypeMessage("Array", value, get), line, charpos);
+	}
 	
 	public static String invalidTypeMessage(String type, String value, Object obj) {
 		return "Incorrect type \""+type+"\" for value: \""+value+"\" of type "+obj.getClass().getName();
 	}
 
-	public abstract void setValue(AVarTextCompiler compiler, Object value) throws CompileException;
+	public abstract void setValue(AV2Compiler compiler, Object value) throws CompileException;
+
+	public abstract boolean isConstant() throws CompileException;
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/AV2Value.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/AV2Value.java
@@ -2,16 +2,24 @@ package io.github.ngspace.hudder.v2runtime.values;
 
 import java.util.Objects;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.methods.MethodValue;
 
-public abstract class AV2Value extends MethodValue { protected AV2Value() {}
+public abstract class AV2Value extends MethodValue {
 	/**
 	 * Return the current value of the Object
 	 * @return an Object of any kind.
 	 * @throws CompileException - failed to get value of object
 	 */
 	public abstract Object get() throws CompileException;
+	
+	protected final int line;
+	protected final int charpos;
+	protected AV2Value(int line, int charpos) {
+		this.line = line;
+		this.charpos = charpos;
+	}
 	
 	/**
 	 * Returns true if the variable has a value and false if it does not
@@ -22,7 +30,7 @@ public abstract class AV2Value extends MethodValue { protected AV2Value() {}
 	public boolean compare(AV2Value other, String comparisonOperator) throws CompileException {
 		Object val1 = get();
 		Object val2 = other.get();
-		if (other.getAbsoluteValue().equalsIgnoreCase("unset")) return !hasValue();
+		if (other.getAbsoluteValue()!=null&&other.getAbsoluteValue().equalsIgnoreCase("unset")) return !hasValue();
 		boolean areNums = false;
 		double dou1 = 0;
 		double dou2 = 0;
@@ -59,25 +67,27 @@ public abstract class AV2Value extends MethodValue { protected AV2Value() {}
 	@Override public boolean asBoolean() throws CompileException {
 		Object get = get();
 		if (get instanceof Boolean b) return b;
-		throw new CompileException(invalidTypeMessage("Boolean", value, get));
+		throw new CompileException(invalidTypeMessage("Boolean", value, get), line, charpos);
 	}
 	@Override public double asDouble() throws CompileException {
 		Object get = get();
 		if (get instanceof Number b) return b.doubleValue();
-		throw new CompileException(invalidTypeMessage("Double", value, get));
+		throw new CompileException(invalidTypeMessage("Double", value, get), line, charpos);
 	}
 	@Override public int asInt() throws CompileException {
 		Object get = get();
 		if (get instanceof Number b) return b.intValue();
-		throw new CompileException(invalidTypeMessage("Integer", value, get));
+		throw new CompileException(invalidTypeMessage("Integer", value, get), line, charpos);
 	}
 	@Override public String asString() throws CompileException {
 		Object get = get();
 		if (get instanceof String b) return b;
-		throw new CompileException(invalidTypeMessage("String", value, get));
+		throw new CompileException(invalidTypeMessage("String", value, get), line, charpos);
 	}
 	
 	public static String invalidTypeMessage(String type, String value, Object obj) {
 		return "Incorrect type \""+type+"\" for value: \""+value+"\" of type "+obj.getClass().getName();
 	}
+
+	public abstract void setValue(AVarTextCompiler compiler, Object value) throws CompileException;
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Array.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Array.java
@@ -3,7 +3,6 @@ package io.github.ngspace.hudder.v2runtime.values;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
@@ -16,20 +15,19 @@ public class V2Array extends AV2Value {
 			throws CompileException {
 		super(line, charpos);
 		values = new AV2Value[strings.length];
-		for (int i = 0;i<strings.length;i++) {
+		for (int i = 0;i<strings.length;i++)
 			values[i] = compiler.getV2Value(runtime, strings[i], line, charpos);
-		}
 	}
 
-	@Override public Object get() throws CompileException {
+	@Override public List<Object> get() throws CompileException {
 		List<Object> array = new ArrayList<Object>();
-		for (int i = 0;i<values.length;i++)
-			array.add(values[i].get());
+		for (int i = 0;i<values.length;i++) array.add(values[i].get());
 		return array;
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
-		//TODO CHANGE THIS
-		throw new CompileException("", line, charpos);
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of an array constant", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return false;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Array.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Array.java
@@ -1,0 +1,35 @@
+package io.github.ngspace.hudder.v2runtime.values;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
+import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
+import io.github.ngspace.hudder.v2runtime.V2Runtime;
+
+public class V2Array extends AV2Value {
+
+	private AV2Value[] values;
+
+	protected V2Array(String[] strings, AV2Compiler compiler, V2Runtime runtime, int line, int charpos)
+			throws CompileException {
+		super(line, charpos);
+		values = new AV2Value[strings.length];
+		for (int i = 0;i<strings.length;i++) {
+			values[i] = compiler.getV2Value(runtime, strings[i], line, charpos);
+		}
+	}
+
+	@Override public Object get() throws CompileException {
+		List<Object> array = new ArrayList<Object>();
+		for (int i = 0;i<values.length;i++)
+			array.add(values[i].get());
+		return array;
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		//TODO CHANGE THIS
+		throw new CompileException("", line, charpos);
+	}
+}

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ArrayRead.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ArrayRead.java
@@ -1,0 +1,51 @@
+package io.github.ngspace.hudder.v2runtime.values;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.github.ngspace.hudder.Hudder;
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
+import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
+import io.github.ngspace.hudder.v2runtime.V2Runtime;
+
+public class V2ArrayRead extends AV2Value {
+	
+	AV2Value indexValue;
+	AV2Value array;
+	
+	protected V2ArrayRead(String value, AV2Compiler compiler, V2Runtime runtime, int line, int charpos) throws CompileException {
+		super(line, charpos);
+		int indexstart = value.lastIndexOf('[');
+		String index = value.substring(indexstart+1,value.length()-1);
+		indexValue = compiler.getV2Value(runtime, index, line, charpos);
+		array = compiler.getV2Value(runtime, value.substring(0, indexstart), line, charpos);
+		var res = new ArrayList<Object>();
+		
+		int r = new int[] {1,2}[1];
+		
+		for (char c : value.toCharArray())
+			res.add(c);
+//		compiler.put(value.substring(0, indexstart-1), res);
+	}
+
+	@Override public Object get() throws CompileException {
+		@SuppressWarnings("unchecked")
+		var list = (List<Object>) array.get();
+		return list.get(indexValue.asInt());
+	}
+
+	@Override
+	public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		@SuppressWarnings("unchecked")
+		var list = (List<Object>) array.get();
+		int index = indexValue.asInt();
+		if (index==list.size()) {
+			list.add(value);
+		} else if (index>list.size()) {
+			throw new CompileException("You can't set value " + index + " of array before all previous points are set",line,charpos);
+		} else list.set(index, value);
+	}
+	
+}

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ArrayRead.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ArrayRead.java
@@ -1,11 +1,7 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import io.github.ngspace.hudder.Hudder;
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
@@ -21,25 +17,14 @@ public class V2ArrayRead extends AV2Value {
 		String index = value.substring(indexstart+1,value.length()-1);
 		indexValue = compiler.getV2Value(runtime, index, line, charpos);
 		array = compiler.getV2Value(runtime, value.substring(0, indexstart), line, charpos);
-		var res = new ArrayList<Object>();
-		
-		int r = new int[] {1,2}[1];
-		
-		for (char c : value.toCharArray())
-			res.add(c);
-//		compiler.put(value.substring(0, indexstart-1), res);
 	}
 
 	@Override public Object get() throws CompileException {
-		@SuppressWarnings("unchecked")
-		var list = (List<Object>) array.get();
-		return list.get(indexValue.asInt());
+		return array.asList().get(indexValue.asInt());
 	}
 
-	@Override
-	public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
-		@SuppressWarnings("unchecked")
-		var list = (List<Object>) array.get();
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
+		List<Object> list = array.asList();
 		int index = indexValue.asInt();
 		if (index==list.size()) {
 			list.add(value);
@@ -48,4 +33,6 @@ public class V2ArrayRead extends AV2Value {
 		} else list.set(index, value);
 	}
 	
+	//Even if the given array's isConstant function returns true, since the value of this can change then it is
+	@Override public boolean isConstant() throws CompileException {return false;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Boolean.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Boolean.java
@@ -2,6 +2,7 @@ package io.github.ngspace.hudder.v2runtime.values;
 
 import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2Boolean extends AV2Value {
 	
@@ -17,17 +18,18 @@ public class V2Boolean extends AV2Value {
 	
 	@Override public boolean asBoolean() throws CompileException {return get();}
 	@Override public double asDouble() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Double", value, false));
+		throw new CompileException(invalidTypeMessage("Double", value, false),line,charpos);
 	}
 	@Override public int asInt() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Int", value, false));
+		throw new CompileException(invalidTypeMessage("Int", value, false),line,charpos);
 	}
 	@Override public String asString() throws CompileException {
-		throw new CompileException(invalidTypeMessage("String", value, false));
+		throw new CompileException(invalidTypeMessage("String", value, false),line,charpos);
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a boolean constant", line, charpos);
 	}
+	@Override public boolean isConstant() throws CompileException {return true;}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Boolean.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Boolean.java
@@ -7,7 +7,11 @@ public class V2Boolean extends AV2Value {
 	
 	boolean bvalue;
 	
-	public V2Boolean(boolean value, AVarTextCompiler compiler) {this.bvalue = value;this.compiler = compiler;}
+	public V2Boolean(boolean value, AVarTextCompiler compiler, int line, int charpos) {
+		super(line,charpos);
+		this.bvalue = value;
+		this.compiler = compiler;
+	}
 
 	@Override public Boolean get() throws CompileException {return bvalue;}
 	
@@ -20,6 +24,10 @@ public class V2Boolean extends AV2Value {
 	}
 	@Override public String asString() throws CompileException {
 		throw new CompileException(invalidTypeMessage("String", value, false));
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a boolean constant", line, charpos);
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Comparison.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Comparison.java
@@ -1,25 +1,30 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2Comparison extends AV2Value {
 	public AV2Value value1;
 	public String operator;
 	public AV2Value value2;
+	public Object constant = null;
 
-	public V2Comparison(AV2Value value1, AV2Value value2, String operator, int line, int charpos) {super(line, charpos);
+	public V2Comparison(AV2Value value1, AV2Value value2, String operator, int line, int charpos)
+			throws CompileException {super(line, charpos);
 		this.value1 = value1;
 		this.operator = operator;
 		this.value2 = value2;
+		if (isConstant()) constant = get();
 	}
 	@Override
 	public Object get() throws CompileException {
+		if (constant!=null) return constant;
 		 return value1.compare(value2, operator);
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a comparison between values", line, charpos);
 	}
 	
+	@Override public boolean isConstant() throws CompileException {return value1.isConstant()&&value2.isConstant();}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Comparison.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Comparison.java
@@ -1,5 +1,6 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2Comparison extends AV2Value {
@@ -7,7 +8,7 @@ public class V2Comparison extends AV2Value {
 	public String operator;
 	public AV2Value value2;
 
-	public V2Comparison(AV2Value value1, AV2Value value2, String operator) {
+	public V2Comparison(AV2Value value1, AV2Value value2, String operator, int line, int charpos) {super(line, charpos);
 		this.value1 = value1;
 		this.operator = operator;
 		this.value2 = value2;
@@ -15,6 +16,10 @@ public class V2Comparison extends AV2Value {
 	@Override
 	public Object get() throws CompileException {
 		 return value1.compare(value2, operator);
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a comparison between values", line, charpos);
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2DynamicVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2DynamicVar.java
@@ -4,11 +4,18 @@ import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2DynamicVar extends AV2Value {
-	public V2DynamicVar(String value, AVarTextCompiler compiler) {this.value=value;this.compiler=compiler;}
+	public V2DynamicVar(String value, AVarTextCompiler compiler, int line, int charpos) {super(line, charpos);
+		this.value=value;
+		this.compiler=compiler;
+	}
 	
 	@Override public Object get() throws CompileException {
 		return compiler.getDynamicVariable(value);
 	}
 	
 	@Override public boolean hasValue() {return compiler.get(value)!=null;}
+
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		compiler.put(this.value, value);
+	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2FunctionVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2FunctionVar.java
@@ -1,6 +1,5 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
@@ -10,23 +9,28 @@ public class V2FunctionVar extends AV2Value {
 	IV2Function func;
 	V2Runtime runtime;
 	AV2Value[] args = new AV2Value[0];
+	private String funcname;
 
 	public V2FunctionVar(V2Runtime runtime, AV2Compiler compiler, String name, String[] nonprocessedargs, int line, int charpos) throws CompileException {
 		super(line,charpos);
 		this.runtime = runtime;
 		this.func = runtime.functionHandler.getFunction(name);
 		if (func==null) throw new CompileException("Unknown function name: \""+name+'"', line, charpos);
+		this.funcname = name;
 		this.args = new AV2Value[nonprocessedargs.length];
 		
-		for (int i = 0;i<nonprocessedargs.length;i++) this.args[i] = compiler.getV2Value(runtime, nonprocessedargs[i]);
+		for (int i = 0;i<nonprocessedargs.length;i++)
+			this.args[i] = compiler.getV2Value(runtime, nonprocessedargs[i], line, charpos);
 	}
 
 	@Override public Object get() throws CompileException {
-		return func.execute(runtime, value, args);
+		return func.execute(runtime, funcname, args, line, charpos);
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a function", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return false;}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2FunctionVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2FunctionVar.java
@@ -1,5 +1,6 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 import io.github.ngspace.hudder.v2runtime.V2Runtime;
@@ -10,22 +11,22 @@ public class V2FunctionVar extends AV2Value {
 	V2Runtime runtime;
 	AV2Value[] args = new AV2Value[0];
 
-	public V2FunctionVar(V2Runtime runtime, AV2Compiler compiler, String name, String[] nonprocessedargs) throws CompileException {
+	public V2FunctionVar(V2Runtime runtime, AV2Compiler compiler, String name, String[] nonprocessedargs, int line, int charpos) throws CompileException {
+		super(line,charpos);
 		this.runtime = runtime;
 		this.func = runtime.functionHandler.getFunction(name);
+		if (func==null) throw new CompileException("Unknown function name: \""+name+'"', line, charpos);
 		this.args = new AV2Value[nonprocessedargs.length];
 		
 		for (int i = 0;i<nonprocessedargs.length;i++) this.args[i] = compiler.getV2Value(runtime, nonprocessedargs[i]);
 	}
-	public V2FunctionVar(V2Runtime runtime, String name, AV2Value[] args) {
-		this.runtime = runtime;
-		this.func = runtime.functionHandler.getFunction(name);
-		this.args = args;
-	}
 
-	@Override
-	public Object get() throws CompileException {
+	@Override public Object get() throws CompileException {
 		return func.execute(runtime, value, args);
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a function", line, charpos);
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2MathOperation.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2MathOperation.java
@@ -1,12 +1,13 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2MathOperation extends AV2Value {
 	public AV2Value[] values = new AV2Value[0];
 	public char[] operations = new char[0];
 	
-	public V2MathOperation(AV2Value[] values, char[] operations) {
+	public V2MathOperation(AV2Value[] values, char[] operations, int line, int charpos) {super(line, charpos);
 		this.values = values;
 		this.operations = operations;
 	}
@@ -47,6 +48,9 @@ public class V2MathOperation extends AV2Value {
 			else if (secondsOperations[i]=='-') result = result - val2;
 		}
 		return result;
+	}
 	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a math operation", line, charpos);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2MathOperation.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2MathOperation.java
@@ -1,19 +1,23 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2MathOperation extends AV2Value {
 	public AV2Value[] values = new AV2Value[0];
 	public char[] operations = new char[0];
+	public Object constant = null;
 	
-	public V2MathOperation(AV2Value[] values, char[] operations, int line, int charpos) {super(line, charpos);
+	public V2MathOperation(AV2Value[] values, char[] operations, int line, int charpos) throws CompileException {
+		super(line, charpos);
 		this.values = values;
 		this.operations = operations;
+		if (isConstant()) constant = get();
 	}
 	
 	@SuppressWarnings("removal")
-	@Override public Double get() throws CompileException {
+	@Override public Object get() throws CompileException {
+		if (constant!=null) return constant;
 		
 		double[] secondValues = new double[values.length];
 		char[] secondsOperations = new char[operations.length];
@@ -50,7 +54,9 @@ public class V2MathOperation extends AV2Value {
 		return result;
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a math operation", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return false;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Number.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Number.java
@@ -1,11 +1,12 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2Number extends AV2Value {
 	double doubleVal;
-	public V2Number(String value, int line, int charpos) {super(line, charpos);
+	public V2Number(String value, int line, int charpos) {
+		super(line, charpos);
 		this.value=value;
 		if (value.startsWith("0x")||value.startsWith("#"))
 			this.doubleVal = Long.decode(value);
@@ -16,15 +17,17 @@ public class V2Number extends AV2Value {
 	@Override public Double get() throws CompileException {return doubleVal;}
 	
 	@Override public boolean asBoolean() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Boolean", value, 0d));
+		throw new CompileException(invalidTypeMessage("Boolean", value, 0d),line,charpos);
 	}
 	@Override public double asDouble() throws CompileException {return get();}
 	@Override public int asInt() throws CompileException {return get().intValue();}
 	@Override public String asString() throws CompileException {
-		throw new CompileException(invalidTypeMessage("String", value, 0d));
+		throw new CompileException(invalidTypeMessage("String", value, 0d),line,charpos);
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a number constant", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return true;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Number.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2Number.java
@@ -1,12 +1,16 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2Number extends AV2Value {
 	double doubleVal;
-	public V2Number(double value) {
-		this.value=Double.toString(value);
-		this.doubleVal = value;
+	public V2Number(String value, int line, int charpos) {super(line, charpos);
+		this.value=value;
+		if (value.startsWith("0x")||value.startsWith("#"))
+			this.doubleVal = Long.decode(value);
+		else
+			this.doubleVal = Double.parseDouble(value);
 	}
 	
 	@Override public Double get() throws CompileException {return doubleVal;}
@@ -18,5 +22,9 @@ public class V2Number extends AV2Value {
 	@Override public int asInt() throws CompileException {return get().intValue();}
 	@Override public String asString() throws CompileException {
 		throw new CompileException(invalidTypeMessage("String", value, 0d));
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a number constant", line, charpos);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SetValue.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SetValue.java
@@ -1,13 +1,14 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
+import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2SetValue extends AV2Value {
-	public String key;
+	public AV2Value key;
 	public AV2Value valueToSet;
 
-	public V2SetValue(String key, AV2Value valueToSet, AV2Compiler compiler) {
+	public V2SetValue(AV2Value key, AV2Value valueToSet, AV2Compiler compiler, int line, int charpos) {super(line, charpos);
 		this.key = key;
 		this.valueToSet = valueToSet;
 		this.compiler = compiler;
@@ -15,8 +16,11 @@ public class V2SetValue extends AV2Value {
 	@Override
 	public Object get() throws CompileException {
 		Object ohsaycanyousee = valueToSet.get();//I'm not American, I'm just sleep deprived.
-		compiler.put(key, ohsaycanyousee);
+		key.setValue(compiler, ohsaycanyousee);
 		return ohsaycanyousee;
+	}
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("If you receive this message, it's a bug, report it to the creator of Hudder: 01", line, charpos);
 	}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SetValue.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SetValue.java
@@ -1,26 +1,29 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2SetValue extends AV2Value {
 	public AV2Value key;
 	public AV2Value valueToSet;
+	private AV2Compiler compilerv2;
 
 	public V2SetValue(AV2Value key, AV2Value valueToSet, AV2Compiler compiler, int line, int charpos) {super(line, charpos);
 		this.key = key;
 		this.valueToSet = valueToSet;
 		this.compiler = compiler;
+		this.compilerv2 = compiler;
 	}
 	@Override
 	public Object get() throws CompileException {
 		Object ohsaycanyousee = valueToSet.get();//I'm not American, I'm just sleep deprived.
-		key.setValue(compiler, ohsaycanyousee);
+		key.setValue(compilerv2, ohsaycanyousee);
 		return ohsaycanyousee;
 	}
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
-		throw new CompileException("If you receive this message, it's a bug, report it to the creator of Hudder: 01", line, charpos);
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
+		throw new CompileException("If you receive this message, it's a bug, report it to the creator of Hudder: 01",
+				line, charpos);
 	}
+	@Override public boolean isConstant() throws CompileException {return valueToSet.isConstant();}
 	
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2String.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2String.java
@@ -4,7 +4,11 @@ import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2String extends AV2Value {
-	public V2String(String value, AVarTextCompiler compiler) {this.value=value;this.compiler=compiler;}
+	public V2String(String value, AVarTextCompiler compiler, int line, int charpos) {
+		super(line, charpos);
+		this.value=value;
+		this.compiler=compiler;
+	}
 	
 	@Override public String get() throws CompileException {return value;}
 	
@@ -18,4 +22,8 @@ public class V2String extends AV2Value {
 		throw new CompileException(invalidTypeMessage("Int", value, ""));
 	}
 	@Override public String asString() throws CompileException {return get();}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Can't change the value of a string constant", line, charpos);
+	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2String.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2String.java
@@ -2,6 +2,7 @@ package io.github.ngspace.hudder.v2runtime.values;
 
 import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2String extends AV2Value {
 	public V2String(String value, AVarTextCompiler compiler, int line, int charpos) {
@@ -13,17 +14,19 @@ public class V2String extends AV2Value {
 	@Override public String get() throws CompileException {return value;}
 	
 	@Override public boolean asBoolean() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Boolean", value, ""));
+		throw new CompileException(invalidTypeMessage("Boolean", value, ""),line,charpos);
 	}
 	@Override public double asDouble() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Double", value, ""));
+		throw new CompileException(invalidTypeMessage("Double", value, ""),line,charpos);
 	}
 	@Override public int asInt() throws CompileException {
-		throw new CompileException(invalidTypeMessage("Int", value, ""));
+		throw new CompileException(invalidTypeMessage("Int", value, ""),line,charpos);
 	}
 	@Override public String asString() throws CompileException {return get();}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Can't change the value of a string constant", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return true;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SystemVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SystemVar.java
@@ -2,11 +2,12 @@ package io.github.ngspace.hudder.v2runtime.values;
 
 import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
+import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
 public class V2SystemVar extends AV2Value {
 	public V2SystemVar(String value, AVarTextCompiler compiler, int line, int charpos) {
 		super(line, charpos);
-		this.value=value;
+		this.value=value.toLowerCase();
 		this.compiler=compiler;
 	}
 	
@@ -14,7 +15,9 @@ public class V2SystemVar extends AV2Value {
 		return compiler.getSystemVariable(value);
 	}
 	
-	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
 		throw new CompileException("Variable \""+this.value+"\" Can not be changed as it is set by the system", line, charpos);
 	}
+	
+	@Override public boolean isConstant() throws CompileException {return false;}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SystemVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2SystemVar.java
@@ -4,9 +4,17 @@ import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 
 public class V2SystemVar extends AV2Value {
-	public V2SystemVar(String value, AVarTextCompiler compiler) {this.value=value;this.compiler=compiler;}
+	public V2SystemVar(String value, AVarTextCompiler compiler, int line, int charpos) {
+		super(line, charpos);
+		this.value=value;
+		this.compiler=compiler;
+	}
 	
 	@Override public Object get() throws CompileException {
 		return compiler.getSystemVariable(value);
+	}
+	
+	@Override public void setValue(AVarTextCompiler compiler, Object value) throws CompileException {
+		throw new CompileException("Variable \""+this.value+"\" Can not be changed as it is set by the system", line, charpos);
 	}
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2TempDynamicVar.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2TempDynamicVar.java
@@ -1,25 +1,39 @@
 package io.github.ngspace.hudder.v2runtime.values;
 
-import io.github.ngspace.hudder.compilers.AVarTextCompiler;
 import io.github.ngspace.hudder.compilers.utils.CompileException;
 import io.github.ngspace.hudder.v2runtime.AV2Compiler;
 
-public class V2DynamicVar extends AV2Value {
-	public V2DynamicVar(String value, AVarTextCompiler compiler, int line, int charpos) {
+public class V2TempDynamicVar extends AV2Value {
+	private AV2Compiler compilerv2;
+
+	public V2TempDynamicVar(String value, AV2Compiler compiler, int line, int charpos) {
 		super(line, charpos);
 		this.value=value.toLowerCase();
 		this.compiler=compiler;
+		this.compilerv2=compiler;
 	}
 	
 	@Override public Object get() throws CompileException {
-		return compiler.getDynamicVariable(value);
+		return compilerv2.getTempVariable(value);
 	}
 	
 	@Override public boolean hasValue() {return compiler.get(value)!=null;}
 
 	@Override public void setValue(AV2Compiler compiler, Object value) throws CompileException {
-		compiler.put(this.value, value);
+		compiler.putTemp(this.value, value);
 	}
 	
 	@Override public boolean isConstant() throws CompileException {return false;}
+	
+	/*
+	 * This is done to allow {_temp=_temp+1} even when {_temp} is not set
+	 */
+	@Override public double asDouble() throws CompileException {
+		try {
+			return super.asDouble();
+		} catch (Exception e) {
+			return 0;
+		}
+	}
+
 }

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ValueParser.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ValueParser.java
@@ -20,7 +20,7 @@ public class V2ValueParser {private V2ValueParser() {}
 			return compiler.getV2Value(runtime, value.substring(1, value.length()-1), line, charpos);
 		
 		//Double constant
-		if (value.matches("((0x|#)[\\daAbBcCdDeEfF]+|[-+]*\\d+(\\.?(\\d+)?))"))
+		if (value.matches("((0x|#)[\\daAbBcCdDeEfF]+|[-+]*\\d*(\\.?(\\d+)?))"))
 			return new V2Number(value, line, charpos);
 
 		if (value.equalsIgnoreCase("false")) return new V2Boolean(false, compiler, line, charpos);

--- a/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ValueParser.java
+++ b/src/main/java/io/github/ngspace/hudder/v2runtime/values/V2ValueParser.java
@@ -11,36 +11,51 @@ public class V2ValueParser {private V2ValueParser() {}
 	
 	//Only after writing 80% of the values did I realize having one class that is all values is bad, I tried to
 	//lower the burden but as you can see it's too late, the damage has already been done... maybe in a later update...
-	public static AV2Value of(V2Runtime runtime, String valuee, AV2Compiler compiler) throws CompileException {
+	public static AV2Value of(V2Runtime runtime, String valuee, AV2Compiler compiler, int line, int charpos) throws CompileException {
 		String value = valuee.trim();
 		AV2Value temp = null;
 		
+		if (value.startsWith("(")&&value.endsWith(")"))
+			return compiler.getV2Value(runtime, value.substring(1, value.length()-1), line, charpos);
 		
 		//Double constant
-		try {return new V2Number(Double.parseDouble(value));} catch (Exception e) {/*Do Nothin*/}
-		
+		if (value.matches("((0x|#)[\\daAbBcCdDeEfF]+|[\\d]+(\\.?\\d?))"))
+			return new V2Number(value, line, charpos);
 
-		if (value.equalsIgnoreCase("false")) return new V2Boolean(false, compiler);
-		if (value.equalsIgnoreCase("true")) return new V2Boolean(true, compiler);
+		if (value.equalsIgnoreCase("false")) return new V2Boolean(false, compiler, line, charpos);
+		if (value.equalsIgnoreCase("true")) return new V2Boolean(true, compiler, line, charpos);
 		
 		
 		//String constant
-		if ((temp = string(value, compiler))!=null) return temp;
+		if ((temp = string(value, compiler, line, charpos))!=null) return temp;
 		
+		//Array constant
+		if (value.matches("\\[.*\\]"))
+			return new V2Array(HudderUtils.processParemeters(value.substring(1, value.length()-1)), compiler, runtime,
+					line, charpos);
 		
 		//Set variable
 		String[] setValues = value.split("=",2);
 		if (setValues.length==2&&!compiler.isCondition(value)) 
-			return new V2SetValue(setValues[0].toLowerCase(), compiler.getV2Value(runtime, setValues[1]), compiler);
+			return new V2SetValue(compiler.getV2Value(runtime, setValues[0].toLowerCase(),line,charpos), compiler.getV2Value(runtime, setValues[1], line, charpos), compiler, line, charpos);
 		
+		boolean matchesVariableRegex = value.matches("[A-Za-z\\d_]+");
 		
 		//System variable
-		if (compiler.isSystemVariable(value.toLowerCase())) return new V2SystemVar(value.toLowerCase(), compiler);
+		if (matchesVariableRegex&&compiler.isSystemVariable(value.toLowerCase()))
+			return new V2SystemVar(value.toLowerCase(), compiler, line, charpos);
 		
 		
 		//Dynamic variable
-		if (compiler.isDynamicVariable(value.toLowerCase())) return new V2DynamicVar(value.toLowerCase(), compiler);
+		if (matchesVariableRegex) return new V2DynamicVar(value.toLowerCase(), compiler, line, charpos);
 		
+		
+		//Read Array
+		if (value.matches("[A-Za-z\\d_]+ *\\[.+\\]"))
+			return new V2ArrayRead(value, compiler, runtime, line, charpos);
+		
+		
+		//Function variable
 		if (!value.startsWith("(")&&value.endsWith(")")) {
 			int argStart = value.indexOf("(");
 			if (argStart!=-1) {
@@ -49,9 +64,16 @@ public class V2ValueParser {private V2ValueParser() {}
 					String parametersString = value.substring(argStart+1, value.length()-1);
 					String[] tokenizedArgs = HudderUtils.processParemeters(parametersString);
 					
-					return new V2FunctionVar(runtime, compiler, funcName, tokenizedArgs);
+					return new V2FunctionVar(runtime, compiler, funcName, tokenizedArgs, line, charpos);
 				}
 			}
+		}
+		
+		//Comparing values
+		var operator = compiler.getOperator(value);
+		if (operator!=null) {
+			var v = value.split(operator,2);
+			return new V2Comparison(compiler.getV2Value(runtime, v[0].trim(), line, charpos), compiler.getV2Value(runtime, v[1].trim(), line, charpos), operator, line, charpos);
 		}
 		
 		
@@ -88,7 +110,7 @@ public class V2ValueParser {private V2ValueParser() {}
 				continue;
 			}
 			if (c=='+'||c=='-'||c=='*'||c=='/'||c=='%') {
-				values = addToArray(values, compiler.getV2Value(runtime, mathvalue.toString()));
+				values = addToArray(values, compiler.getV2Value(runtime, mathvalue.toString(), line, charpos));
 				operations = addToArray(operations, c);
 				mathvalue.setLength(0);
 				continue;
@@ -96,19 +118,15 @@ public class V2ValueParser {private V2ValueParser() {}
 			mathvalue.append(c);
 		}
 		if (values.length>0) {
-			values = addToArray(values, compiler.getV2Value(runtime, mathvalue.toString()));
-			return new V2MathOperation(values,operations);
+			values = addToArray(values, compiler.getV2Value(runtime, mathvalue.toString(), line, charpos));
+			return new V2MathOperation(values,operations, line, charpos);
 		}
 		
-		//Comparing values
-		var operator = compiler.getOperator(value);
-		var v = value.split(operator,2);
-		return new V2Comparison(compiler.getV2Value(runtime, v[0].trim()), compiler.getV2Value(runtime, v[1].trim()), operator);
-		
 		// Fallback
+		throw new CompileException("Unknown variable: " + value, line, charpos);
 	}
 	
-	private static V2String string(String value, AV2Compiler compiler) {
+	private static V2String string(String value, AV2Compiler compiler, int line, int charpos) {
 		//Maybe String :)
 		if (!value.startsWith("\"")||!value.endsWith("\"")) return null;
 		
@@ -119,6 +137,10 @@ public class V2ValueParser {private V2ValueParser() {}
 		boolean safe = false;
 		for (int i = 0;i<value.length();i++) {
 			c = value.charAt(i);
+			if (c=='n'&&safe) {
+				string.append('\n');
+				continue;
+			}
 			if (c=='\\'&&!safe) safe = true;
 			else {
 				if (c=='"'&&!safe) return null; //Not String ;_;
@@ -127,7 +149,7 @@ public class V2ValueParser {private V2ValueParser() {}
 			}
 		}
 		//String! :D
-		return new V2String(string.toString(), compiler);
+		return new V2String(string.toString(), compiler, line, charpos);
 	}
 	
 	private static <T> T[] addToArray(T[] arr, T t) {

--- a/src/main/resources/assets/hudder/UnitTests.hudder
+++ b/src/main/resources/assets/hudder/UnitTests.hudder
@@ -29,6 +29,22 @@ Basic Bitch Test
 ||EXPECT||
 ong
 
+||INPUT||Array length
+{length([1,"4"])}
+||EXPECT||
+2
+
+||INPUT||2D Arrays
+{2darr=[[0,1],[2,3]]}
+{2darr[1][0]}
+{2darr[1][1]=4}
+{2darr}
+||EXPECT||
+[[0.0, 1.0], [2.0, 3.0]]
+2
+4
+[[0.0, 1.0], [2.0, 4.0]]
+
 ||INPUT||Fibonacci
 ;mute;
 {r=""}

--- a/src/main/resources/assets/hudder/UnitTests.hudder
+++ b/src/main/resources/assets/hudder/UnitTests.hudder
@@ -126,14 +126,16 @@ CaSE SenSitive CaSE SenSitive CaSE SenSitive
 &6PING: &220
 
 ||INPUT||Putall method
-#def putall, string, number, boolean
-	{str=arg1}
-	{num=arg2}
-	{bool=arg3}
-;putall, "text", 10, false;
-{str} {num} {bool}
+#def putall, string, number, boolean, array, any
+	{str=int(arg1)}
+	{num=str(arg2)}
+	{bool=arg3==false}
+	{array=arg4[0]}
+	{any=arg5}
+;putall, "1", 10, true, ["yes","no"], "no";
+{str} {num} {bool} {array} {any}
 ||EXPECT||
-text 10 false
+1 10.0 false yes no
 
 ||INPUT||Divide method
 #def divide, number, number

--- a/src/main/resources/assets/hudder/UnitTests.hudder
+++ b/src/main/resources/assets/hudder/UnitTests.hudder
@@ -29,6 +29,22 @@ Basic Bitch Test
 ||EXPECT||
 ong
 
+||INPUT||Fibonacci
+;mute;
+{r=""}
+{N=0}
+{num1=0}{num2=1}
+#while N<20
+	{N=N+1}
+	{r=concat(r, concat(str(num1,true)," "))}
+	{num3=num2+num1}
+	{num1=num2}
+	{num2=num3}
+;topleft,1;
+{r}
+||EXPECT||
+0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 1597 2584 4181 
+
 ||INPUT||Text repeat
 {repeat("Repeat", 2)}
 ||EXPECT||

--- a/src/main/resources/assets/hudder/armor
+++ b/src/main/resources/assets/hudder/armor
@@ -10,7 +10,7 @@ Calculate how much we need to scale the item to make it fit a fixed a fixed widt
 
 8 pixels
 
-;helmet,width/2-tempscale-offset-guiscale,height/2-tempscale+.5,itemscale;
-;chestplate,width/2-tempscale-offset-guiscale,height/2+.1,itemscale;
-;pants,width/2-offset+guiscale+.5,height/2-tempscale+.5,itemscale;
-;boots,width/2-offset+guiscale+.5,height/2+.5,itemscale;
+;helmet,width/2-tempscale-offset-guiscale,height/2-tempscale+0.5,itemscale;
+;chestplate,width/2-tempscale-offset-guiscale,height/2+0.1,itemscale;
+;pants,width/2-offset+guiscale+0.5,height/2-tempscale+0.5,itemscale;
+;boots,width/2-offset+guiscale+0.5,height/2+0.5,itemscale;

--- a/src/main/resources/assets/hudder/armorside
+++ b/src/main/resources/assets/hudder/armorside
@@ -1,0 +1,18 @@
+;mute; GUIScale 5 is the basis of the calculations
+
+Item size - can be changed
+{itemsize=.9}
+
+Calculate how much we need to scale the item to make it fit a fixed a fixed width, height and position.
+{itemscale=(itemsize/guiscale)*5}
+%guiscale==6, "{offset=0}","{offset=0.5}"%
+{tempscale=itemscale*16}
+
+8 pixels
+{xonscreen=width-tempscale-3}
+{yonscreen=height-tempscale*2-7}
+
+;helmet,xonscreen,yonscreen-tempscale-tempscale/2+3,itemscale;
+;chestplate,xonscreen,yonscreen-tempscale/2,itemscale;
+;pants,xonscreen,yonscreen+tempscale/2,itemscale;
+;boots,xonscreen,yonscreen+tempscale+tempscale/2-2,itemscale;

--- a/src/main/resources/assets/hudder/basic
+++ b/src/main/resources/assets/hudder/basic
@@ -1,2 +1,2 @@
 &r{FPS} (max. {maxfps} avg. {avgfps} min. {minfps}) {usedram_percentage}\% of {maxram}MB
-X: {x}, Y: {y}, Z: {z}; run, hand;
+X: {x}, Y: {y}, Z: {z}; run, "hand";

--- a/src/main/resources/assets/hudder/fibonacci
+++ b/src/main/resources/assets/hudder/fibonacci
@@ -1,0 +1,18 @@
+;mute;
+{fibonacci=""}
+{N=0}
+{num1=0}{num2=1}
+{expectedwidth=0}
+#while N<93
+	{N=N+1}
+	{numstr=str(num1,true)}
+	{expectedwidth=expectedwidth+(strwidth(concat(numstr," ")))}
+	#if expectedwidth>=width/2
+		{numstr=concat("\n", numstr)}
+		{expectedwidth=0}
+	{fibonacci=concat(fibonacci, concat(numstr," "))}
+	{num3=num2+num1}
+	{num1=num2}
+	{num2=num3}
+;topleft,1;
+{fibonacci}

--- a/src/main/resources/assets/hudder/fibonacci
+++ b/src/main/resources/assets/hudder/fibonacci
@@ -15,4 +15,5 @@
 	{num1=num2}
 	{num2=num3}
 ;topleft,1;
+Here are the numbers of the fibonacci sequence (up to 93rd number):
 {fibonacci}

--- a/src/main/resources/assets/hudder/hud
+++ b/src/main/resources/assets/hudder/hud
@@ -1,2 +1,2 @@
 &6FPS: &r{FPS} &6GPU: &r{gpu} %ping>5, "&6PING: &%ping>=400,\"4\",ping>=100,\"e\","2"%{ping} "%&6Mem: &%usedram_percentage>70, "4", usedram_percentage>40, "e", "2"%{usedram_percentage}\%&r of &6{maxram}&rMB
-XYZ: {x} {y} {z} ;run, "hand";
+XYZ: {x} {y} {z} ;run, "hand";;run, "armorside";

--- a/src/main/resources/assets/hudder/hud.js
+++ b/src/main/resources/assets/hudder/hud.js
@@ -5,7 +5,6 @@ function formatString(template, ...args) {
   });
 }
 function topleft() {
-	
 	if (getBoolean("removegui")) compile("hotbar.js");
 	
 	let itemsize = get("itemsize") !== null?parseInt(get("itemsize")):0.8;
@@ -13,7 +12,9 @@ function topleft() {
 	let itemscale = (itemsize/gui)*5;
 	drawSlot(getNumber("selectedslot"), getNumber("width")/2-(itemscale*8)-(gui==6?0:.5),
 		getNumber("height")/2+(itemscale/itemsize*gui)*2.9,itemscale,true);
-	return formatString("\u00A7r{0} (max. {1} avg. {2} min. {3}) {4}% of {5}MB\nX: {6}, Y: {7}, Z: {8}",
+	return formatString(
+		"\u00A7r{0} (max. {1} avg. {2} min. {3}) {4}% of {5}MB\nX: {6}, Y: {7}, Z: {8}",
+		
 		getNumber("fps"), getNumber("maxfps"),getNumber("avgfps"),getNumber("minfps"),getNumber("usedram_percentage"),
 		getNumber("maxram"), getNumber("x"),getNumber("y"),getNumber("z"));
 }

--- a/src/main/resources/assets/hudder/tutorial
+++ b/src/main/resources/assets/hudder/tutorial
@@ -1,19 +1,17 @@
 ;topleft;
-&6Welcome to hudder!
-You can go into hudder's settings and change the main file to:
+&6Welcome to &dHudder!
+&6You can go into &dHudder's settings&6 and change the main file to:
 - "hud"
 - "hand"
 - "armor"
+- "armorside"
 - "basic"
-- "hand"
-- if you want to use javascript you can use:
+- "fibonacci"
+&3- if you want to use JavaScript you can use:
 - "hud.js"
 - "hotbar.js"
-- or create your own hud!
-
-;bottomleft;
-
-for a tutorial on how to make your own hud you can go to Hudder's wiki
+&3- or create your own hud!
 
 
 
+&6A tutorial on how to make your own hud is available on &dHudder's wiki

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "hudder",
-	"version": "5.0.0",
+	"version": "5.5.0",
 	"name": "Hudder",
 	"description": "Add a highly customizable hud to your game!",
 	"authors": [


### PR DESCRIPTION
# Added

+ Added Arrays
+ Added "array" Function that converts a string to an array of it's chars
+ Modified the "Length" Function to accept arrays and return it's length.
+ Modified the "str" Function to accepts arrays and convert them into strings.
+ Added "itemname", "itemdurability", "itemmaxdurability", "itemcount", "itemmaxcount" Functions
+ Added "array" and "any" types to #def methods
+ Added Temporary variables with _ prefix (Will be deleted every tick)
+ Added support for hex numbers and colors with either the "#" or "0x" prefix
+ Added "armorside" builtin hud that shows what armor you are wearing in the bottom right corner of the screen.
+ Added "fibonacci" builtin hud that calculates then shows you the numbers of the Fibonacci sequence (up to 93rd number)

# Removed

+ Remove strwidth method (check wiki for alternatives)

# Changed

+ Deprecated "name",  "durability", "maxdurability", "count", "maxcount" (check wiki for alternatives)
+ Background on text is now enabled by default
+ Errors while parsing variables are now more specific in their description.
+ Errors now point to the line and col in which the error happened (Added to improve the debugging experience)
+ Errors now render with shadow enabled at all times
+ Optimized certain operations who's results don't change.
+ You can no longer "modify" the value of system variables
+ Changed the default hud ("hud") to execute "armorside" hud too.
+ Changed the default hud ("hud") to execute "armorside" hud too.
+ Gave the "tutorial" hud a new face.

# Fixed

+ Fixed color of background text
+ Fixed a bug with the methods not parsing values correctly