### PR TITLE
Render Hudder behind toasts

### DIFF
--- a/src/main/java/dev/ngspace/hudder/Hudder.java
+++ b/src/main/java/dev/ngspace/hudder/Hudder.java
@@ -32,6 +32,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.KeyMapping;
@@ -151,7 +152,7 @@ public class Hudder implements ClientModInitializer {
 		ClientTickEvents.END_CLIENT_TICK.register(compman);
         
 		HudderRenderer renderer = new HudderRenderer(compman);
-		HudElementRegistry.addLast(renderer.hudElementRegistryID, renderer);
+		HudElementRegistry.attachElementAfter(VanillaHudElements.CHAT, renderer.hudElementRegistryID, renderer);
         
         ClientLifecycleEvents.CLIENT_STARTED.register(_->{
 			try {


### PR DESCRIPTION
After I updated my instance to 1.21.11, I noticed that, other than in 1.21.10 Hudders hud renders on top of toasts which I find to be pretty annoying.
It seems now the toasts are rendered between the hud elements and not after them.
Chat is the last element that is rendered before the toasts, so I placed it there.
I don't know which other implications this might have, but it worked fine for me.