### PR TITLE
Allow RectangleElement with float coordinates

### DIFF
--- a/src/main/java/dev/ngspace/hudder/api/functionsandconsumers/HudderBuiltInMethods.java
+++ b/src/main/java/dev/ngspace/hudder/api/functionsandconsumers/HudderBuiltInMethods.java
@@ -66,7 +66,7 @@ public class HudderBuiltInMethods {
 		// Rectangles
 		api.registerPositionedConsumer(
 				(e,_,_,_,s) -> e.addUIElement(
-						new RectangleElement(s[0].asInt(), s[1].asInt(), s[2].asInt(), s[3].asInt(), s[4].asInt())),
+						new RectangleElement(s[0].asFloat(), s[1].asFloat(), s[2].asFloat(), s[3].asFloat(), s[4].asInt())),
 				"rectangle");
 
 		api.registerPositionedConsumer(

--- a/src/main/java/dev/ngspace/hudder/main/HudderRenderer.java
+++ b/src/main/java/dev/ngspace/hudder/main/HudderRenderer.java
@@ -158,8 +158,12 @@ public class HudderRenderer implements HudElement {
 	
 	
 	
-	public void renderBlock(GuiGraphicsExtractor graphics, int x, int y, int width, int height, int argb) {
-		graphics.fill(x, y, x+width, y+height, argb);
+	public void renderBlock(GuiGraphicsExtractor graphics, float x, float y, float width, float height, int argb) {
+        graphics.pose().pushMatrix();
+        graphics.pose().translate(x, y);
+        graphics.pose().scale(width, height);
+        graphics.fill(0, 0, 1, 1, argb);
+        graphics.pose().popMatrix();
 	}
 	
 	

--- a/src/main/java/dev/ngspace/hudder/uielements/RectangleElement.java
+++ b/src/main/java/dev/ngspace/hudder/uielements/RectangleElement.java
@@ -6,13 +6,13 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 
 public class RectangleElement extends AUIElement {
 
-	final int x;
-	final int y;
-	final int width;
-	final int height;
+	final float x;
+	final float y;
+	final float width;
+	final float height;
 	final int color;
 	
-	public RectangleElement(int x, int y, int width, int height, int color) {
+	public RectangleElement(float x, float y, float width, float height, int color) {
 		this.x = x;
 		this.y = y;
 		this.width = width;


### PR DESCRIPTION
As the colorvertices seem to behave weirdly with images and chat (idk) I wanted to switch to the new `rectangle`, but it can only be placed in full gui scaled pixels. This PR changes that so I can switch.